### PR TITLE
Ensure that `use_cuda` is passed to `to_var` and `to_tensor`

### DIFF
--- a/skorch/callbacks.py
+++ b/skorch/callbacks.py
@@ -172,7 +172,8 @@ class Scoring(Callback):
                 raise NameError("A metric called '{}' does not exist, "
                                 "use a valid sklearn metric name."
                                 "".format(self.scoring))
-            y_pred = self.pred_extractor(net.infer(to_var(X)))
+            y_pred = self.pred_extractor(
+                net.infer(to_var(X, use_cuda=net.use_cuda)))
             score = scorer(y, y_pred)
         else:
             # scoring is a function

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -924,7 +924,7 @@ class NeuralNetClassifier(NeuralNet):
         return y
 
     def get_loss(self, y_pred, y_true, X=None, train=False):
-        y_true = to_var(y_true)
+        y_true = to_var(y_true, use_cuda=self.use_cuda)
         y_pred_log = torch.log(y_pred)
         return self.criterion_(
             y_pred_log,

--- a/skorch/tests/test_callbacks.py
+++ b/skorch/tests/test_callbacks.py
@@ -50,7 +50,7 @@ class TestScoring:
     @pytest.yield_fixture
     def scoring_cls(self):
         with patch('skorch.callbacks.to_var') as to_var:
-            to_var.side_effect = lambda x: x
+            to_var.side_effect = lambda x, use_cuda: x
 
             from skorch.callbacks import Scoring
             yield partial(

--- a/skorch/tests/test_dataset.py
+++ b/skorch/tests/test_dataset.py
@@ -853,8 +853,8 @@ class TestCVSplit:
 
     def test_with_torch_tensors(self, cv_split_cls, data):
         X, y = data
-        X = to_tensor(X)
-        y = to_tensor(y)
+        X = to_tensor(X, use_cuda=False)
+        y = to_tensor(y, use_cuda=False)
         m = self.num_samples // 5
         n = self.num_samples - m
 
@@ -863,11 +863,11 @@ class TestCVSplit:
         assert len(X_valid) == len(y_valid) == m
 
     def test_with_torch_tensors_and_stratified(self, cv_split_cls, data):
-        X = to_tensor(data[0])
+        X = to_tensor(data[0], use_cuda=False)
         num_expected = self.num_samples // 4
         y = np.hstack([np.repeat([0, 0, 0], num_expected),
                        np.repeat([1], num_expected)])
-        y = to_tensor(y)
+        y = to_tensor(y, use_cuda=False)
         _, _, y_train, y_valid = cv_split_cls(5, stratified=True)(X, y)
         assert y_train.sum() == 0.8 * num_expected
         assert y_valid.sum() == 0.2 * num_expected

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -445,7 +445,7 @@ class TestNeuralNet:
         class MyNet(net_cls):
             # pylint: disable=unused-argument
             def get_loss(self, y_pred, y_true, X=None, train=False):
-                y_true = to_var(y_true)
+                y_true = to_var(y_true, use_cuda=False)
                 loss_a = torch.abs(y_true.float() - y_pred[:, 1]).mean()
                 loss_b = ((y_true.float() - y_pred[:, 1]) ** 2).mean()
                 if train:

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -23,7 +23,7 @@ class Ansi(Enum):
     ENDC = '\033[0m'
 
 
-def to_var(X, use_cuda=False):
+def to_var(X, use_cuda):
     """Generic function to convert a input data to pytorch Variables.
 
     Returns X when it already is a pytorch Variable.
@@ -34,15 +34,15 @@ def to_var(X, use_cuda=False):
 
     X = to_tensor(X, use_cuda=use_cuda)
     if isinstance(X, dict):
-        return {k: to_var(v) for k, v in X.items()}
+        return {k: to_var(v, use_cuda=use_cuda) for k, v in X.items()}
 
     if isinstance(X, (tuple, list)):
-        return [to_var(x) for x in X]
+        return [to_var(x, use_cuda=use_cuda) for x in X]
 
     return Variable(X)
 
 
-def to_tensor(X, use_cuda=False):
+def to_tensor(X, use_cuda):
     """Turn to torch Variable.
 
     Handles the cases:


### PR DESCRIPTION
To achieve this, remove `use_cuda=False` as default argument.

Addresses #66 