### PR TITLE
Add more examples to notebook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Example
 -------
 
 To see a more elaborate example, look `here
-notebook <https://github.com/dnouri/skorch/tree/master/notebooks/README.md>`__.
+<https://github.com/dnouri/skorch/tree/master/notebooks/README.md>`__.
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ A scikit-learn compatible neural network library that wraps pytorch.
 Example
 -------
 
-To see a more elaborate example, check out `this
-notebook <https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/Basic_Usage.ipynb>`__
+To see a more elaborate example, look `here
+notebook <https://github.com/dnouri/skorch/tree/master/notebooks/README.md>`__.
 
 .. code:: python
 

--- a/notebooks/Advanced_Usage.ipynb
+++ b/notebooks/Advanced_Usage.ipynb
@@ -15,6 +15,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Table of contents"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* [Setup](#Setup)\n",
+    "* [Callbacks](#Callbacks)\n",
+    "  * [Writing your own callback](#Writing-a-custom-callback)\n",
+    "  * [Accessing callback parameters](#Accessing-callback-parameters)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -36,20 +53,6 @@
    "outputs": [],
    "source": [
     "torch.manual_seed(0);"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Table of contents"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "* [Custom callbacks](#Writing-custom-callbacks)"
    ]
   },
   {
@@ -182,24 +185,43 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Writing custom callbacks"
+    "## Callbacks"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Writing your own callbacks is also straightforward. Just remember these rules:\n",
+    "Callbacks are a powerful and flexible way to customize the behavior of your neural network. They are all called at specific points during the model training, e.g. when training starts, or after each batch. Have a look at the `skorch.callbacks` module to see the callbacks that are already implemented."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Writing a custom callback"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Although `skorch` comes with a handful of useful callbacks, you may find that you would like to write your own callbacks. Doing so is straightforward, just remember these rules:\n",
     "* They should inherit from `skorch.callbacks.Callback`.\n",
     "* They should implement at least one of the `on_`-methods provided by the parent class (e.g. `on_batch_begin` or `on_epoch_end`).\n",
-    "* As argument, the `on_`-methods first get the `NeuralNet` instance, and, where appropriate, the local data (e.g. the data from the current batch). The method should also have `**kwargs` in the signature for potentially unused arguments."
+    "* As argument, the `on_`-methods first get the `NeuralNet` instance, and, where appropriate, the local data (e.g. the data from the current batch). The method should also have `**kwargs` in the signature for potentially unused arguments.\n",
+    "* *Optional*: If you have attributes that should be reset when the model is re-initialized, those attributes should be set in the `initialize` method."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here is an example of a callback that saves the model if the validation loss has improved."
+    "Here is an example of a callback that remembers at which epoch the validation accuracy reached a certain value. Then, when training is finished, it calls a mock Twitter API and tweets that epoch. We proceed as follows:\n",
+    "* We set the desired minimum accuracy during `__init__`.\n",
+    "* We set the critical epoch during `initialize`.\n",
+    "* After each epoch, if the critical accuracy has not yet been reached, we check if it was reached.\n",
+    "* When training finishes, we send a tweet informing us whether our training was successful or not."
    ]
   },
   {
@@ -213,28 +235,57 @@
     "from skorch.callbacks import Callback\n",
     "\n",
     "\n",
-    "class Checkpoint(Callback):\n",
-    "    def __init__(self, file_name):\n",
-    "        self.file_name = file_name\n",
+    "def tweet(msg):\n",
+    "    print(\"~\" * 60)\n",
+    "    print(\"*tweet*\", msg, \"#skorch #pytorch\")\n",
+    "    print(\"~\" * 60)\n",
+    "\n",
+    "\n",
+    "class AccuracyTweet(Callback):\n",
+    "    def __init__(self, min_accuracy):\n",
+    "        self.min_accuracy = min_accuracy\n",
+    "\n",
+    "    def initialize(self):\n",
+    "        self.critical_epoch_ = -1\n",
     "\n",
     "    def on_epoch_end(self, net, **kwargs):\n",
-    "        # check if valid accuracy of most recent epoch is the best so far\n",
-    "        if net.history[-1, 'valid_acc_best']:\n",
-    "            print(\"Save model to {}.\".format(self.file_name))\n",
-    "            net.save_params(self.file_name)"
+    "        if self.critical_epoch_ > -1:\n",
+    "            return\n",
+    "        # look at the validation accuracy of the last epoch\n",
+    "        if net.history[-1, 'valid_acc'] >= self.min_accuracy:\n",
+    "            self.critical_epoch_ = len(net.history)\n",
+    "\n",
+    "    def on_train_end(self, net, **kwargs):\n",
+    "        if self.critical_epoch_ < 0:\n",
+    "            msg = \"Accuracy never reached {} :(\".format(self.min_accuracy)\n",
+    "        else:\n",
+    "            msg = \"Accuracy reached {} at epoch {}!!!\".format(\n",
+    "                self.min_accuracy, self.critical_epoch_)\n",
+    "\n",
+    "        tweet(msg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we initialize a `NeuralNetClassifier` and pass your new callback in a list to the `callbacks` argument. After that, we train the model and see what happens."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "net = NeuralNetClassifier(\n",
     "    ClassifierModule,\n",
-    "    max_epochs=20,\n",
-    "    callbacks=[Checkpoint(file_name='/tmp/mymodel.pkl')],\n",
+    "    max_epochs=10,\n",
     "    lr=0.1,\n",
+    "    cold_start=False,\n",
+    "    callbacks=[AccuracyTweet(min_accuracy=0.7)],\n",
     ")"
    ]
   },
@@ -247,49 +298,256 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Save model to /tmp/mymodel.pkl.\n",
       "  epoch    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ------------  -----------  ------------  ------\n",
-      "      1        \u001b[36m0.7111\u001b[0m       \u001b[32m0.5100\u001b[0m        \u001b[35m0.6894\u001b[0m  0.1296\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "      2        \u001b[36m0.6928\u001b[0m       \u001b[32m0.5500\u001b[0m        \u001b[35m0.6803\u001b[0m  0.0597\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "      3        \u001b[36m0.6833\u001b[0m       \u001b[32m0.5650\u001b[0m        \u001b[35m0.6741\u001b[0m  0.0541\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "      4        \u001b[36m0.6763\u001b[0m       \u001b[32m0.5850\u001b[0m        \u001b[35m0.6674\u001b[0m  0.0536\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "      5        \u001b[36m0.6727\u001b[0m       \u001b[32m0.6450\u001b[0m        \u001b[35m0.6616\u001b[0m  0.0544\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "      6        \u001b[36m0.6606\u001b[0m       \u001b[32m0.6600\u001b[0m        \u001b[35m0.6536\u001b[0m  0.0455\n",
-      "      7        \u001b[36m0.6560\u001b[0m       0.6600        \u001b[35m0.6443\u001b[0m  0.0526\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "      8        \u001b[36m0.6427\u001b[0m       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6354\u001b[0m  0.0534\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "      9        \u001b[36m0.6300\u001b[0m       \u001b[32m0.6800\u001b[0m        \u001b[35m0.6264\u001b[0m  0.0943\n",
-      "     10        \u001b[36m0.6289\u001b[0m       0.6800        \u001b[35m0.6189\u001b[0m  0.1214\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "     11        \u001b[36m0.6241\u001b[0m       \u001b[32m0.7150\u001b[0m        \u001b[35m0.6114\u001b[0m  0.1129\n",
-      "     12        \u001b[36m0.6132\u001b[0m       0.7150        \u001b[35m0.6017\u001b[0m  0.0517\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "     13        \u001b[36m0.5950\u001b[0m       \u001b[32m0.7350\u001b[0m        \u001b[35m0.5902\u001b[0m  0.0665\n",
-      "     14        \u001b[36m0.5914\u001b[0m       0.7200        \u001b[35m0.5831\u001b[0m  0.1201\n",
-      "     15        \u001b[36m0.5784\u001b[0m       0.7300        \u001b[35m0.5733\u001b[0m  0.0762\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "     16        0.5816       \u001b[32m0.7400\u001b[0m        \u001b[35m0.5665\u001b[0m  0.0576\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "     17        \u001b[36m0.5766\u001b[0m       \u001b[32m0.7450\u001b[0m        \u001b[35m0.5616\u001b[0m  0.0589\n",
-      "     18        \u001b[36m0.5636\u001b[0m       0.7450        \u001b[35m0.5559\u001b[0m  0.0748\n",
-      "     19        \u001b[36m0.5517\u001b[0m       0.7350        \u001b[35m0.5527\u001b[0m  0.0664\n",
-      "     20        0.5570       0.7350        \u001b[35m0.5492\u001b[0m  0.0557\n"
+      "      1        \u001b[36m0.7111\u001b[0m       \u001b[32m0.5100\u001b[0m        \u001b[35m0.6894\u001b[0m  0.1552\n",
+      "      2        \u001b[36m0.6928\u001b[0m       \u001b[32m0.5500\u001b[0m        \u001b[35m0.6803\u001b[0m  0.0554\n",
+      "      3        \u001b[36m0.6833\u001b[0m       \u001b[32m0.5650\u001b[0m        \u001b[35m0.6741\u001b[0m  0.0534\n",
+      "      4        \u001b[36m0.6763\u001b[0m       \u001b[32m0.5850\u001b[0m        \u001b[35m0.6674\u001b[0m  0.0547\n",
+      "      5        \u001b[36m0.6727\u001b[0m       \u001b[32m0.6450\u001b[0m        \u001b[35m0.6616\u001b[0m  0.0795\n",
+      "      6        \u001b[36m0.6606\u001b[0m       \u001b[32m0.6600\u001b[0m        \u001b[35m0.6536\u001b[0m  0.0643\n",
+      "      7        \u001b[36m0.6560\u001b[0m       0.6600        \u001b[35m0.6443\u001b[0m  0.0532\n",
+      "      8        \u001b[36m0.6427\u001b[0m       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6354\u001b[0m  0.0784\n",
+      "      9        \u001b[36m0.6300\u001b[0m       \u001b[32m0.6800\u001b[0m        \u001b[35m0.6264\u001b[0m  0.1540\n",
+      "     10        \u001b[36m0.6289\u001b[0m       0.6800        \u001b[35m0.6189\u001b[0m  0.0632\n",
+      "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
+      "*tweet* Accuracy never reached 0.7 :( #skorch #pytorch\n",
+      "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<skorch.net.NeuralNetClassifier at 0x7f1e55e502e8>"
+       "<skorch.net.NeuralNetClassifier at 0x7fe8a8214438>"
       ]
      },
      "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "net.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Oh no, our model never reached a validation accuracy of 0.7. Let's train some more (this is possible because we set `cold_start=False`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     11        \u001b[36m0.6241\u001b[0m       \u001b[32m0.7150\u001b[0m        \u001b[35m0.6114\u001b[0m  0.1174\n",
+      "     12        \u001b[36m0.6132\u001b[0m       0.7150        \u001b[35m0.6017\u001b[0m  0.1397\n",
+      "     13        \u001b[36m0.5950\u001b[0m       \u001b[32m0.7350\u001b[0m        \u001b[35m0.5902\u001b[0m  0.2457\n",
+      "     14        \u001b[36m0.5914\u001b[0m       0.7200        \u001b[35m0.5831\u001b[0m  0.2226\n",
+      "     15        \u001b[36m0.5784\u001b[0m       0.7300        \u001b[35m0.5733\u001b[0m  0.1469\n",
+      "     16        0.5816       \u001b[32m0.7400\u001b[0m        \u001b[35m0.5665\u001b[0m  0.1852\n",
+      "     17        \u001b[36m0.5766\u001b[0m       \u001b[32m0.7450\u001b[0m        \u001b[35m0.5616\u001b[0m  0.1034\n",
+      "     18        \u001b[36m0.5636\u001b[0m       0.7450        \u001b[35m0.5559\u001b[0m  0.1243\n",
+      "     19        \u001b[36m0.5517\u001b[0m       0.7350        \u001b[35m0.5527\u001b[0m  0.1246\n",
+      "     20        0.5570       0.7350        \u001b[35m0.5492\u001b[0m  0.1318\n",
+      "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
+      "*tweet* Accuracy reached 0.7 at epoch 11!!! #skorch #pytorch\n",
+      "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<skorch.net.NeuralNetClassifier at 0x7fe8a8214438>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "net.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, the validation score exceeded 0.7. Hooray!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Accessing callback parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Say you would like to use a learning rate schedule with your neural net, but you don't know what parameters are best for that schedule. Wouldn't it be nice if you could find those parameters with a grid search? With `skorch`, this is possible. Below, we show how to access the parameters of your callbacks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To simplify the access to your callback parameters, it is best if you give your callback a name. This is achieved by passing the `callbacks` parameter a list of *name*, *callback* tuples, such as:\n",
+    "\n",
+    "    callbacks=[\n",
+    "        ('scheduler', LearningRateScheduler)),\n",
+    "        ...\n",
+    "    ],\n",
+    "    \n",
+    "This way, you can access your callbacks using the double underscore semantics (as, for instance, in an `sklearn` `Pipeline`):\n",
+    "\n",
+    "    callbacks__scheduler__epoch=50,\n",
+    "\n",
+    "So if you would like to perform a grid search on, say, the number of units in the hidden layer and the learning rate schedule, it could look something like this:\n",
+    "\n",
+    "    param_grid = {\n",
+    "        'module__num_units': [50, 100, 150],\n",
+    "        'callbacks__scheduler__epoch': [10, 50, 100],\n",
+    "    }\n",
+    "    \n",
+    "*Note*: If you would like to refresh your knowledge on grid search, look [here](http://scikit-learn.org/stable/modules/grid_search.html#grid-search), [here](http://scikit-learn.org/stable/auto_examples/model_selection/grid_search_text_feature_extraction.html), or in the *Basic_Usage* notebok."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below, we show how accessing the callback parameters works our `AccuracyTweet` callback:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "net = NeuralNetClassifier(\n",
+    "    ClassifierModule,\n",
+    "    max_epochs=10,\n",
+    "    lr=0.1,\n",
+    "    cold_start=False,\n",
+    "    callbacks=[\n",
+    "        ('tweet', AccuracyTweet(min_accuracy=0.7)),\n",
+    "    ],\n",
+    "    callbacks__tweet__min_accuracy=0.6,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  epoch    train_loss    valid_acc    valid_loss     dur\n",
+      "-------  ------------  -----------  ------------  ------\n",
+      "      1        \u001b[36m0.7261\u001b[0m       \u001b[32m0.5050\u001b[0m        \u001b[35m0.6986\u001b[0m  0.1680\n",
+      "      2        \u001b[36m0.6977\u001b[0m       \u001b[32m0.5350\u001b[0m        \u001b[35m0.6889\u001b[0m  0.1411\n",
+      "      3        \u001b[36m0.6897\u001b[0m       \u001b[32m0.5550\u001b[0m        \u001b[35m0.6844\u001b[0m  0.1202\n",
+      "      4        \u001b[36m0.6846\u001b[0m       \u001b[32m0.5800\u001b[0m        \u001b[35m0.6813\u001b[0m  0.0879\n",
+      "      5        \u001b[36m0.6788\u001b[0m       0.5800        \u001b[35m0.6768\u001b[0m  0.0641\n",
+      "      6        \u001b[36m0.6725\u001b[0m       0.5800        \u001b[35m0.6731\u001b[0m  0.0881\n",
+      "      7        \u001b[36m0.6711\u001b[0m       \u001b[32m0.5950\u001b[0m        \u001b[35m0.6689\u001b[0m  0.0708\n",
+      "      8        \u001b[36m0.6581\u001b[0m       \u001b[32m0.6150\u001b[0m        \u001b[35m0.6650\u001b[0m  0.0975\n",
+      "      9        0.6648       0.6050        \u001b[35m0.6605\u001b[0m  0.1186\n",
+      "     10        \u001b[36m0.6550\u001b[0m       0.6150        \u001b[35m0.6549\u001b[0m  0.1199\n",
+      "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
+      "*tweet* Accuracy reached 0.6 at epoch 8!!! #skorch #pytorch\n",
+      "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<skorch.net.NeuralNetClassifier at 0x7fe8a8204668>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "net.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see, by passing `callbacks__tweet__min_accuracy=0.6`, we changed that parameter. The same can be achieved by calling the `set_params` method with the corresponding arguments:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<skorch.net.NeuralNetClassifier at 0x7fe8a8204668>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "net.set_params(callbacks__tweet__min_accuracy=0.75)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  epoch    train_loss    valid_acc    valid_loss     dur\n",
+      "-------  ------------  -----------  ------------  ------\n",
+      "     11        \u001b[36m0.6435\u001b[0m       \u001b[32m0.6250\u001b[0m        \u001b[35m0.6492\u001b[0m  0.2017\n",
+      "     12        0.6435       \u001b[32m0.6350\u001b[0m        \u001b[35m0.6437\u001b[0m  0.1521\n",
+      "     13        \u001b[36m0.6267\u001b[0m       \u001b[32m0.6450\u001b[0m        \u001b[35m0.6375\u001b[0m  0.0861\n",
+      "     14        \u001b[36m0.6214\u001b[0m       \u001b[32m0.6800\u001b[0m        \u001b[35m0.6306\u001b[0m  0.1819\n",
+      "     15        \u001b[36m0.6185\u001b[0m       0.6750        \u001b[35m0.6239\u001b[0m  0.0761\n",
+      "     16        \u001b[36m0.6060\u001b[0m       0.6750        \u001b[35m0.6154\u001b[0m  0.2071\n",
+      "     17        \u001b[36m0.5964\u001b[0m       \u001b[32m0.6850\u001b[0m        \u001b[35m0.6061\u001b[0m  0.1707\n",
+      "     18        \u001b[36m0.5868\u001b[0m       \u001b[32m0.7000\u001b[0m        \u001b[35m0.5964\u001b[0m  0.1347\n",
+      "     19        \u001b[36m0.5693\u001b[0m       \u001b[32m0.7150\u001b[0m        \u001b[35m0.5859\u001b[0m  0.1106\n",
+      "     20        \u001b[36m0.5689\u001b[0m       \u001b[32m0.7200\u001b[0m        \u001b[35m0.5793\u001b[0m  0.1101\n",
+      "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
+      "*tweet* Accuracy never reached 0.75 :( #skorch #pytorch\n",
+      "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<skorch.net.NeuralNetClassifier at 0x7fe8a8204668>"
+      ]
+     },
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/Advanced_Usage.ipynb
+++ b/notebooks/Advanced_Usage.ipynb
@@ -1,0 +1,323 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Advanced usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook shows some more advanced features of `skorch`. More examples will be added with time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch import nn\n",
+    "import torch.nn.functional as F"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "torch.manual_seed(0);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Table of contents"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* [Custom callbacks](#Writing-custom-callbacks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A toy binary classification task"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We load a toy classification task from `sklearn`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from sklearn.datasets import make_classification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "X, y = make_classification(1000, 20, n_informative=10, random_state=0)\n",
+    "X = X.astype(np.float32)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((1000, 20), (1000,), 0.5)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X.shape, y.shape, y.mean()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Definition of the `pytorch` classification `module`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We define a vanilla neural network with two hidden layers. The output layer should have 2 output units since there are two classes. In addition, it should have a softmax nonlinearity, because later, when calling `predict_proba`, the output from the `forward` call will be used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from skorch.net import NeuralNetClassifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "class ClassifierModule(nn.Module):\n",
+    "    def __init__(\n",
+    "            self,\n",
+    "            num_units=10,\n",
+    "            nonlin=F.relu,\n",
+    "            dropout=0.5,\n",
+    "    ):\n",
+    "        super(ClassifierModule, self).__init__()\n",
+    "        self.num_units = num_units\n",
+    "        self.nonlin = nonlin\n",
+    "        self.dropout = dropout\n",
+    "\n",
+    "        self.dense0 = nn.Linear(20, num_units)\n",
+    "        self.nonlin = nonlin\n",
+    "        self.dropout = nn.Dropout(dropout)\n",
+    "        self.dense1 = nn.Linear(num_units, 10)\n",
+    "        self.output = nn.Linear(10, 2)\n",
+    "\n",
+    "    def forward(self, X, **kwargs):\n",
+    "        X = self.nonlin(self.dense0(X))\n",
+    "        X = self.dropout(X)\n",
+    "        X = F.relu(self.dense1(X))\n",
+    "        X = F.softmax(self.output(X))\n",
+    "        return X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Writing custom callbacks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Writing your own callbacks is also straightforward. Just remember these rules:\n",
+    "* They should inherit from `skorch.callbacks.Callback`.\n",
+    "* They should implement at least one of the `on_`-methods provided by the parent class (e.g. `on_batch_begin` or `on_epoch_end`).\n",
+    "* As argument, the `on_`-methods first get the `NeuralNet` instance, and, where appropriate, the local data (e.g. the data from the current batch). The method should also have `**kwargs` in the signature for potentially unused arguments."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is an example of a callback that saves the model if the validation loss has improved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from skorch.callbacks import Callback\n",
+    "\n",
+    "\n",
+    "class Checkpoint(Callback):\n",
+    "    def __init__(self, file_name):\n",
+    "        self.file_name = file_name\n",
+    "\n",
+    "    def on_epoch_end(self, net, **kwargs):\n",
+    "        # check if valid accuracy of most recent epoch is the best so far\n",
+    "        if net.history[-1, 'valid_acc_best']:\n",
+    "            print(\"Save model to {}.\".format(self.file_name))\n",
+    "            net.save_params(self.file_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "net = NeuralNetClassifier(\n",
+    "    ClassifierModule,\n",
+    "    max_epochs=20,\n",
+    "    callbacks=[Checkpoint(file_name='/tmp/mymodel.pkl')],\n",
+    "    lr=0.1,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Save model to /tmp/mymodel.pkl.\n",
+      "  epoch    train_loss    valid_acc    valid_loss     dur\n",
+      "-------  ------------  -----------  ------------  ------\n",
+      "      1        \u001b[36m0.7111\u001b[0m       \u001b[32m0.5100\u001b[0m        \u001b[35m0.6894\u001b[0m  0.1296\n",
+      "Save model to /tmp/mymodel.pkl.\n",
+      "      2        \u001b[36m0.6928\u001b[0m       \u001b[32m0.5500\u001b[0m        \u001b[35m0.6803\u001b[0m  0.0597\n",
+      "Save model to /tmp/mymodel.pkl.\n",
+      "      3        \u001b[36m0.6833\u001b[0m       \u001b[32m0.5650\u001b[0m        \u001b[35m0.6741\u001b[0m  0.0541\n",
+      "Save model to /tmp/mymodel.pkl.\n",
+      "      4        \u001b[36m0.6763\u001b[0m       \u001b[32m0.5850\u001b[0m        \u001b[35m0.6674\u001b[0m  0.0536\n",
+      "Save model to /tmp/mymodel.pkl.\n",
+      "      5        \u001b[36m0.6727\u001b[0m       \u001b[32m0.6450\u001b[0m        \u001b[35m0.6616\u001b[0m  0.0544\n",
+      "Save model to /tmp/mymodel.pkl.\n",
+      "      6        \u001b[36m0.6606\u001b[0m       \u001b[32m0.6600\u001b[0m        \u001b[35m0.6536\u001b[0m  0.0455\n",
+      "      7        \u001b[36m0.6560\u001b[0m       0.6600        \u001b[35m0.6443\u001b[0m  0.0526\n",
+      "Save model to /tmp/mymodel.pkl.\n",
+      "      8        \u001b[36m0.6427\u001b[0m       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6354\u001b[0m  0.0534\n",
+      "Save model to /tmp/mymodel.pkl.\n",
+      "      9        \u001b[36m0.6300\u001b[0m       \u001b[32m0.6800\u001b[0m        \u001b[35m0.6264\u001b[0m  0.0943\n",
+      "     10        \u001b[36m0.6289\u001b[0m       0.6800        \u001b[35m0.6189\u001b[0m  0.1214\n",
+      "Save model to /tmp/mymodel.pkl.\n",
+      "     11        \u001b[36m0.6241\u001b[0m       \u001b[32m0.7150\u001b[0m        \u001b[35m0.6114\u001b[0m  0.1129\n",
+      "     12        \u001b[36m0.6132\u001b[0m       0.7150        \u001b[35m0.6017\u001b[0m  0.0517\n",
+      "Save model to /tmp/mymodel.pkl.\n",
+      "     13        \u001b[36m0.5950\u001b[0m       \u001b[32m0.7350\u001b[0m        \u001b[35m0.5902\u001b[0m  0.0665\n",
+      "     14        \u001b[36m0.5914\u001b[0m       0.7200        \u001b[35m0.5831\u001b[0m  0.1201\n",
+      "     15        \u001b[36m0.5784\u001b[0m       0.7300        \u001b[35m0.5733\u001b[0m  0.0762\n",
+      "Save model to /tmp/mymodel.pkl.\n",
+      "     16        0.5816       \u001b[32m0.7400\u001b[0m        \u001b[35m0.5665\u001b[0m  0.0576\n",
+      "Save model to /tmp/mymodel.pkl.\n",
+      "     17        \u001b[36m0.5766\u001b[0m       \u001b[32m0.7450\u001b[0m        \u001b[35m0.5616\u001b[0m  0.0589\n",
+      "     18        \u001b[36m0.5636\u001b[0m       0.7450        \u001b[35m0.5559\u001b[0m  0.0748\n",
+      "     19        \u001b[36m0.5517\u001b[0m       0.7350        \u001b[35m0.5527\u001b[0m  0.0664\n",
+      "     20        0.5570       0.7350        \u001b[35m0.5492\u001b[0m  0.0557\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<skorch.net.NeuralNetClassifier at 0x7f1e55e502e8>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "net.fit(X, y)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Basic_Usage.ipynb
+++ b/notebooks/Basic_Usage.ipynb
@@ -8,6 +8,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*`skorch`* is designed to maximize interoperability between `sklearn` and `pytorch`. The aim is to keep 99% of the flexibility of `pytorch` while being able to leverage most features of `sklearn`. Below, we show the basic usage of `skorch` and how it can be combined with `sklearn`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook shows you how to use the basic functionality of `skorch`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -35,13 +49,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*`skorch`* is designed to maximize interoperability between `sklearn` and `pytorch`. The aim is to keep 99% of the flexibility of `pytorch` while being able to leverage most features of `sklearn`. Below, we show the basic usage of `skorch` and how it can be combined with `sklearn`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Table of contents"
    ]
   },
@@ -50,25 +57,45 @@
    "metadata": {},
    "source": [
     "* [Definition of the pytorch module](#Definition-of-the-pytorch-module)\n",
-    "* [Training a model and predicting](#Training-a-model-and-predicting)\n",
+    "* [Training a classifier](#Training-a-classifier-and-making-predictions)\n",
+    "  * [Dataset](#A-toy-binary-classification-task)\n",
+    "  * [pytorch module](#Definition-of-the-pytorch-classification-module)\n",
+    "  * [Model training](#Defining-and-training-the-neural-net-classifier)\n",
+    "  * [Inference](#Making-predictions,-classification)\n",
+    "* [Training a regressor](#Training-a-regressor)\n",
+    "  * [Dataset](#A-toy-regression-task)\n",
+    "  * [pytorch module](#Definition-of-the-pytorch-regression-module)\n",
+    "  * [Model training](#Defining-and-training-the-neural-net-regressor)\n",
+    "  * [Inference](#Making-predictions,-regression)\n",
     "* [Saving and loading a model](#Saving-and-loading-a-model)\n",
+    "  * [Whole model](#Saving-the-whole-model)\n",
+    "  * [Only parameters](#Saving-only-the-model-parameters)\n",
     "* [Usage with an sklearn Pipeline](#Usage-with-an-sklearn-Pipeline)\n",
     "* [Callbacks](#Callbacks)\n",
-    "* [Grid search](#Usage-with-sklearn-GridSearchCV)"
+    "* [Grid search](#Usage-with-sklearn-GridSearchCV)\n",
+    "  * [Special prefixes](#Special-prefixes)\n",
+    "  * [Performing a grid search](#Performing-a-grid-search)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Toy dataset"
+    "## Training a classifier and making predictions"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is a toy binary classification task"
+    "### A toy binary classification task"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We load a toy classification task from `sklearn`."
    ]
   },
   {
@@ -98,7 +125,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -119,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Definition of the `pytorch module`"
+    "### Definition of the `pytorch` classification `module`"
    ]
   },
   {
@@ -137,14 +166,14 @@
    },
    "outputs": [],
    "source": [
-    "class MyModule(nn.Module):\n",
+    "class ClassifierModule(nn.Module):\n",
     "    def __init__(\n",
     "            self,\n",
     "            num_units=10,\n",
     "            nonlin=F.relu,\n",
     "            dropout=0.5,\n",
     "    ):\n",
-    "        super(MyModule, self).__init__()\n",
+    "        super(ClassifierModule, self).__init__()\n",
     "        self.num_units = num_units\n",
     "        self.nonlin = nonlin\n",
     "        self.dropout = dropout\n",
@@ -167,7 +196,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Training a model and predicting"
+    "### Defining and training the neural net classifier"
    ]
   },
   {
@@ -199,9 +228,10 @@
    "outputs": [],
    "source": [
     "net = NeuralNetClassifier(\n",
-    "    MyModule,\n",
+    "    ClassifierModule,\n",
     "    max_epochs=20,\n",
     "    lr=0.1,\n",
+    "    # use_cuda=True,  # uncomment this to train with CUDA\n",
     ")"
    ]
   },
@@ -221,54 +251,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Automatic pdb calling has been turned ON\n"
-     ]
-    }
-   ],
-   "source": [
-    "pdb on"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "  epoch    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ------------  -----------  ------------  ------\n",
-      "      1        \u001b[36m0.7111\u001b[0m       \u001b[32m0.5100\u001b[0m        \u001b[35m0.6894\u001b[0m  0.1245\n",
-      "      2        \u001b[36m0.6928\u001b[0m       \u001b[32m0.5500\u001b[0m        \u001b[35m0.6803\u001b[0m  0.0601\n",
-      "      3        \u001b[36m0.6833\u001b[0m       \u001b[32m0.5650\u001b[0m        \u001b[35m0.6741\u001b[0m  0.0546\n",
-      "      4        \u001b[36m0.6763\u001b[0m       \u001b[32m0.5850\u001b[0m        \u001b[35m0.6674\u001b[0m  0.0865\n",
-      "      5        \u001b[36m0.6727\u001b[0m       \u001b[32m0.6450\u001b[0m        \u001b[35m0.6616\u001b[0m  0.0726\n",
-      "      6        \u001b[36m0.6606\u001b[0m       \u001b[32m0.6600\u001b[0m        \u001b[35m0.6536\u001b[0m  0.0697\n",
-      "      7        \u001b[36m0.6560\u001b[0m       0.6600        \u001b[35m0.6443\u001b[0m  0.0777\n",
-      "      8        \u001b[36m0.6427\u001b[0m       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6354\u001b[0m  0.0789\n",
-      "      9        \u001b[36m0.6300\u001b[0m       \u001b[32m0.6800\u001b[0m        \u001b[35m0.6264\u001b[0m  0.0956\n",
-      "     10        \u001b[36m0.6289\u001b[0m       0.6800        \u001b[35m0.6189\u001b[0m  0.0537\n",
-      "     11        \u001b[36m0.6241\u001b[0m       \u001b[32m0.7150\u001b[0m        \u001b[35m0.6114\u001b[0m  0.0778\n",
-      "     12        \u001b[36m0.6132\u001b[0m       0.7150        \u001b[35m0.6017\u001b[0m  0.0533\n",
-      "     13        \u001b[36m0.5950\u001b[0m       \u001b[32m0.7350\u001b[0m        \u001b[35m0.5902\u001b[0m  0.0703\n",
-      "     14        \u001b[36m0.5914\u001b[0m       0.7200        \u001b[35m0.5831\u001b[0m  0.0805\n",
-      "     15        \u001b[36m0.5784\u001b[0m       0.7300        \u001b[35m0.5733\u001b[0m  0.0624\n",
-      "     16        0.5816       \u001b[32m0.7400\u001b[0m        \u001b[35m0.5665\u001b[0m  0.0674\n",
-      "     17        \u001b[36m0.5766\u001b[0m       \u001b[32m0.7450\u001b[0m        \u001b[35m0.5616\u001b[0m  0.0596\n",
-      "     18        \u001b[36m0.5636\u001b[0m       0.7450        \u001b[35m0.5559\u001b[0m  0.0610\n",
-      "     19        \u001b[36m0.5517\u001b[0m       0.7350        \u001b[35m0.5527\u001b[0m  0.0633\n",
-      "     20        0.5570       0.7350        \u001b[35m0.5492\u001b[0m  0.0586\n"
+      "      1        \u001b[36m0.7111\u001b[0m       \u001b[32m0.5100\u001b[0m        \u001b[35m0.6894\u001b[0m  0.1124\n",
+      "      2        \u001b[36m0.6928\u001b[0m       \u001b[32m0.5500\u001b[0m        \u001b[35m0.6803\u001b[0m  0.0762\n",
+      "      3        \u001b[36m0.6833\u001b[0m       \u001b[32m0.5650\u001b[0m        \u001b[35m0.6741\u001b[0m  0.0615\n",
+      "      4        \u001b[36m0.6763\u001b[0m       \u001b[32m0.5850\u001b[0m        \u001b[35m0.6674\u001b[0m  0.0626\n",
+      "      5        \u001b[36m0.6727\u001b[0m       \u001b[32m0.6450\u001b[0m        \u001b[35m0.6616\u001b[0m  0.0629\n",
+      "      6        \u001b[36m0.6606\u001b[0m       \u001b[32m0.6600\u001b[0m        \u001b[35m0.6536\u001b[0m  0.1240\n",
+      "      7        \u001b[36m0.6560\u001b[0m       0.6600        \u001b[35m0.6443\u001b[0m  0.0528\n",
+      "      8        \u001b[36m0.6427\u001b[0m       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6354\u001b[0m  0.0604\n",
+      "      9        \u001b[36m0.6300\u001b[0m       \u001b[32m0.6800\u001b[0m        \u001b[35m0.6264\u001b[0m  0.0695\n",
+      "     10        \u001b[36m0.6289\u001b[0m       0.6800        \u001b[35m0.6189\u001b[0m  0.1094\n",
+      "     11        \u001b[36m0.6241\u001b[0m       \u001b[32m0.7150\u001b[0m        \u001b[35m0.6114\u001b[0m  0.0818\n",
+      "     12        \u001b[36m0.6132\u001b[0m       0.7150        \u001b[35m0.6017\u001b[0m  0.0606\n",
+      "     13        \u001b[36m0.5950\u001b[0m       \u001b[32m0.7350\u001b[0m        \u001b[35m0.5902\u001b[0m  0.0570\n",
+      "     14        \u001b[36m0.5914\u001b[0m       0.7200        \u001b[35m0.5831\u001b[0m  0.0590\n",
+      "     15        \u001b[36m0.5784\u001b[0m       0.7300        \u001b[35m0.5733\u001b[0m  0.0553\n",
+      "     16        0.5816       \u001b[32m0.7400\u001b[0m        \u001b[35m0.5665\u001b[0m  0.0612\n",
+      "     17        \u001b[36m0.5766\u001b[0m       \u001b[32m0.7450\u001b[0m        \u001b[35m0.5616\u001b[0m  0.0582\n",
+      "     18        \u001b[36m0.5636\u001b[0m       0.7450        \u001b[35m0.5559\u001b[0m  0.0585\n",
+      "     19        \u001b[36m0.5517\u001b[0m       0.7350        \u001b[35m0.5527\u001b[0m  0.0607\n",
+      "     20        0.5570       0.7350        \u001b[35m0.5492\u001b[0m  0.0585\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<skorch.net.NeuralNetClassifier at 0x7fb8d31230f0>"
+       "<skorch.net.NeuralNetClassifier at 0x7f8a9d2b0a20>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -285,8 +298,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Making predictions, classification"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -295,7 +315,7 @@
        "array([1, 0, 0, 0, 0])"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -307,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -320,7 +340,7 @@
        "       [ 0.65079051,  0.34920952]], dtype=float32)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -328,6 +348,244 @@
    "source": [
     "y_proba = net.predict_proba(X[:5])\n",
     "y_proba"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training a regressor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A toy regression task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.datasets import make_regression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "X_regr, y_regr = make_regression(1000, 20, n_informative=10, random_state=0)\n",
+    "X_regr = X_regr.astype(np.float32)\n",
+    "y_regr = y_regr.astype(np.float32) / 100\n",
+    "y_regr = y_regr.reshape(-1, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((1000, 20), (1000, 1), -6.4901485, 6.1545048)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_regr.shape, y_regr.shape, y_regr.min(), y_regr.max()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Note*: Regression currently requires the target to be 2-dimensional, hence the need to reshape. This should be fixed with an upcoming version of pytorch."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Definition of the `pytorch` regression `module`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again, define a vanilla neural network with two hidden layers. The main difference is that the output layer only has one unit and does not apply a softmax nonlinearity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "class RegressorModule(nn.Module):\n",
+    "    def __init__(\n",
+    "            self,\n",
+    "            num_units=10,\n",
+    "            nonlin=F.relu,\n",
+    "    ):\n",
+    "        super(RegressorModule, self).__init__()\n",
+    "        self.num_units = num_units\n",
+    "        self.nonlin = nonlin\n",
+    "\n",
+    "        self.dense0 = nn.Linear(20, num_units)\n",
+    "        self.nonlin = nonlin\n",
+    "        self.dense1 = nn.Linear(num_units, 10)\n",
+    "        self.output = nn.Linear(10, 1)\n",
+    "\n",
+    "    def forward(self, X, **kwargs):\n",
+    "        X = self.nonlin(self.dense0(X))\n",
+    "        X = F.relu(self.dense1(X))\n",
+    "        X = self.output(X)\n",
+    "        return X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Defining and training the neural net regressor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Training a regressor is almost the same as training a classifier. Mainly, we use `NeuralNetRegressor` instead of `NeuralNetClassifier` (this is the same terminology as in `sklearn`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from skorch.net import NeuralNetRegressor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "net_regr = NeuralNetRegressor(\n",
+    "    RegressorModule,\n",
+    "    max_epochs=20,\n",
+    "    lr=0.1,\n",
+    "    # use_cuda=True,  # uncomment this to train with CUDA\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  epoch    train_loss    valid_loss     dur\n",
+      "-------  ------------  ------------  ------\n",
+      "      1        \u001b[36m4.6084\u001b[0m        \u001b[32m3.8757\u001b[0m  0.0518\n",
+      "      2        \u001b[36m3.9371\u001b[0m        \u001b[32m2.2167\u001b[0m  0.0485\n",
+      "      3        \u001b[36m1.0512\u001b[0m        \u001b[32m0.2644\u001b[0m  0.0378\n",
+      "      4        \u001b[36m0.2770\u001b[0m        0.3933  0.0340\n",
+      "      5        0.3052        \u001b[32m0.1762\u001b[0m  0.0340\n",
+      "      6        \u001b[36m0.1650\u001b[0m        \u001b[32m0.1601\u001b[0m  0.0368\n",
+      "      7        \u001b[36m0.1115\u001b[0m        \u001b[32m0.0990\u001b[0m  0.0322\n",
+      "      8        \u001b[36m0.1067\u001b[0m        0.1418  0.0360\n",
+      "      9        \u001b[36m0.0907\u001b[0m        \u001b[32m0.0828\u001b[0m  0.0355\n",
+      "     10        \u001b[36m0.0792\u001b[0m        \u001b[32m0.0760\u001b[0m  0.0373\n",
+      "     11        \u001b[36m0.0470\u001b[0m        \u001b[32m0.0529\u001b[0m  0.0380\n",
+      "     12        0.0500        \u001b[32m0.0426\u001b[0m  0.0375\n",
+      "     13        \u001b[36m0.0266\u001b[0m        \u001b[32m0.0365\u001b[0m  0.0350\n",
+      "     14        0.0346        \u001b[32m0.0255\u001b[0m  0.0410\n",
+      "     15        \u001b[36m0.0170\u001b[0m        0.0269  0.0421\n",
+      "     16        0.0253        \u001b[32m0.0170\u001b[0m  0.0406\n",
+      "     17        \u001b[36m0.0123\u001b[0m        0.0213  0.0379\n",
+      "     18        0.0197        \u001b[32m0.0122\u001b[0m  0.0338\n",
+      "     19        \u001b[36m0.0096\u001b[0m        0.0177  0.0401\n",
+      "     20        0.0166        \u001b[32m0.0104\u001b[0m  0.0396\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<skorch.net.NeuralNetRegressor at 0x7f8a980a76d8>"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "net_regr.fit(X_regr, y_regr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Making predictions, regression"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You may call `predict` or `predict_proba` on the fitted model. For regressions, both methods return the same value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0.70368975],\n",
+       "       [-1.37799883],\n",
+       "       [-0.60438287],\n",
+       "       [ 0.0090515 ],\n",
+       "       [-0.52674961]], dtype=float32)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y_pred = net_regr.predict(X_regr[:5])\n",
+    "y_pred"
    ]
   },
   {
@@ -350,12 +608,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### The whole model"
+    "### Saving the whole model"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 20,
    "metadata": {
     "collapsed": true
    },
@@ -366,7 +624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 21,
    "metadata": {
     "collapsed": true
    },
@@ -377,9 +635,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/bbossan_dev/anaconda3/envs/skorch/lib/python3.6/site-packages/torch/serialization.py:147: UserWarning: Couldn't retrieve source code for container of type ClassifierModule. It won't be checked for correctness upon loading.\n",
+      "  \"type \" + obj.__name__ + \". It won't be checked \"\n"
+     ]
+    }
+   ],
    "source": [
     "with open(file_name, 'wb') as f:\n",
     "    pickle.dump(net, f)"
@@ -387,7 +654,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 23,
    "metadata": {
     "collapsed": true
    },
@@ -401,7 +668,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Only the parameters"
+    "### Saving only the model parameters"
    ]
   },
   {
@@ -413,7 +680,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 24,
    "metadata": {
     "collapsed": true
    },
@@ -424,15 +691,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 25,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# first initialize the model\n",
     "new_net = NeuralNetClassifier(\n",
-    "    MyModule,\n",
+    "    ClassifierModule,\n",
     "    max_epochs=20,\n",
     "    lr=0.1,\n",
     ").initialize()"
@@ -440,7 +705,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 26,
    "metadata": {
     "collapsed": true
    },
@@ -465,7 +730,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 27,
    "metadata": {
     "collapsed": true
    },
@@ -477,7 +742,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 28,
    "metadata": {
     "collapsed": true
    },
@@ -491,7 +756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -501,36 +766,36 @@
       "Re-initializing module!\n",
       "  epoch    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ------------  -----------  ------------  ------\n",
-      "      1        \u001b[36m0.7102\u001b[0m       \u001b[32m0.5050\u001b[0m        \u001b[35m0.6991\u001b[0m  0.0688\n",
-      "      2        \u001b[36m0.6971\u001b[0m       \u001b[32m0.5100\u001b[0m        \u001b[35m0.6940\u001b[0m  0.0633\n",
-      "      3        \u001b[36m0.6885\u001b[0m       \u001b[32m0.5350\u001b[0m        \u001b[35m0.6896\u001b[0m  0.0443\n",
-      "      4        \u001b[36m0.6878\u001b[0m       \u001b[32m0.5450\u001b[0m        \u001b[35m0.6863\u001b[0m  0.0516\n",
-      "      5        \u001b[36m0.6821\u001b[0m       \u001b[32m0.5750\u001b[0m        \u001b[35m0.6833\u001b[0m  0.0962\n",
-      "      6        0.6845       \u001b[32m0.5850\u001b[0m        \u001b[35m0.6802\u001b[0m  0.0668\n",
-      "      7        \u001b[36m0.6751\u001b[0m       \u001b[32m0.6450\u001b[0m        \u001b[35m0.6760\u001b[0m  0.0601\n",
-      "      8        \u001b[36m0.6716\u001b[0m       \u001b[32m0.6600\u001b[0m        \u001b[35m0.6719\u001b[0m  0.0644\n",
-      "      9        \u001b[36m0.6676\u001b[0m       \u001b[32m0.6700\u001b[0m        \u001b[35m0.6669\u001b[0m  0.0650\n",
-      "     10        \u001b[36m0.6575\u001b[0m       \u001b[32m0.6800\u001b[0m        \u001b[35m0.6591\u001b[0m  0.0552\n",
-      "     11        \u001b[36m0.6510\u001b[0m       \u001b[32m0.6900\u001b[0m        \u001b[35m0.6514\u001b[0m  0.0677\n",
-      "     12        \u001b[36m0.6497\u001b[0m       \u001b[32m0.7100\u001b[0m        \u001b[35m0.6439\u001b[0m  0.1023\n",
-      "     13        \u001b[36m0.6370\u001b[0m       0.7100        \u001b[35m0.6335\u001b[0m  0.0574\n",
-      "     14        \u001b[36m0.6274\u001b[0m       0.7100        \u001b[35m0.6241\u001b[0m  0.0513\n",
-      "     15        0.6306       \u001b[32m0.7200\u001b[0m        \u001b[35m0.6149\u001b[0m  0.0691\n",
-      "     16        \u001b[36m0.6086\u001b[0m       0.7200        \u001b[35m0.6052\u001b[0m  0.0855\n",
-      "     17        \u001b[36m0.5949\u001b[0m       0.7150        \u001b[35m0.5958\u001b[0m  0.0777\n",
-      "     18        0.6004       0.7150        \u001b[35m0.5880\u001b[0m  0.0645\n",
-      "     19        \u001b[36m0.5946\u001b[0m       \u001b[32m0.7250\u001b[0m        \u001b[35m0.5810\u001b[0m  0.0878\n",
-      "     20        \u001b[36m0.5933\u001b[0m       0.7250        \u001b[35m0.5763\u001b[0m  0.0716\n"
+      "      1        \u001b[36m0.6982\u001b[0m       \u001b[32m0.4950\u001b[0m        \u001b[35m0.6960\u001b[0m  0.0959\n",
+      "      2        \u001b[36m0.6943\u001b[0m       \u001b[32m0.5300\u001b[0m        \u001b[35m0.6943\u001b[0m  0.0743\n",
+      "      3        \u001b[36m0.6934\u001b[0m       0.5100        \u001b[35m0.6927\u001b[0m  0.0640\n",
+      "      4        \u001b[36m0.6924\u001b[0m       0.5150        \u001b[35m0.6912\u001b[0m  0.0714\n",
+      "      5        0.6931       0.5100        \u001b[35m0.6899\u001b[0m  0.0622\n",
+      "      6        \u001b[36m0.6897\u001b[0m       \u001b[32m0.5350\u001b[0m        \u001b[35m0.6891\u001b[0m  0.0628\n",
+      "      7        \u001b[36m0.6884\u001b[0m       \u001b[32m0.5450\u001b[0m        \u001b[35m0.6877\u001b[0m  0.0665\n",
+      "      8        \u001b[36m0.6821\u001b[0m       \u001b[32m0.5650\u001b[0m        \u001b[35m0.6856\u001b[0m  0.0761\n",
+      "      9        0.6854       \u001b[32m0.5800\u001b[0m        \u001b[35m0.6835\u001b[0m  0.0648\n",
+      "     10        \u001b[36m0.6801\u001b[0m       \u001b[32m0.6000\u001b[0m        \u001b[35m0.6813\u001b[0m  0.0886\n",
+      "     11        \u001b[36m0.6781\u001b[0m       \u001b[32m0.6150\u001b[0m        \u001b[35m0.6786\u001b[0m  0.0804\n",
+      "     12        \u001b[36m0.6758\u001b[0m       \u001b[32m0.6200\u001b[0m        \u001b[35m0.6757\u001b[0m  0.0838\n",
+      "     13        \u001b[36m0.6715\u001b[0m       \u001b[32m0.6250\u001b[0m        \u001b[35m0.6723\u001b[0m  0.0527\n",
+      "     14        \u001b[36m0.6711\u001b[0m       \u001b[32m0.6350\u001b[0m        \u001b[35m0.6686\u001b[0m  0.0849\n",
+      "     15        \u001b[36m0.6687\u001b[0m       0.6350        \u001b[35m0.6649\u001b[0m  0.0538\n",
+      "     16        \u001b[36m0.6633\u001b[0m       \u001b[32m0.6500\u001b[0m        \u001b[35m0.6604\u001b[0m  0.0564\n",
+      "     17        0.6634       0.6500        \u001b[35m0.6556\u001b[0m  0.1039\n",
+      "     18        \u001b[36m0.6559\u001b[0m       0.6500        \u001b[35m0.6490\u001b[0m  0.1359\n",
+      "     19        \u001b[36m0.6482\u001b[0m       \u001b[32m0.6550\u001b[0m        \u001b[35m0.6430\u001b[0m  0.0622\n",
+      "     20        0.6498       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6375\u001b[0m  0.0802\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "Pipeline(memory=None,\n",
-       "     steps=[('scale', StandardScaler(copy=True, with_mean=True, with_std=True)), ('net', <skorch.net.NeuralNetClassifier object at 0x7fb8d31230f0>)])"
+       "     steps=[('scale', StandardScaler(copy=True, with_mean=True, with_std=True)), ('net', <skorch.net.NeuralNetClassifier object at 0x7f8a9d2b0a20>)])"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -541,20 +806,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[ 0.38140485,  0.61859512],\n",
-       "       [ 0.67595905,  0.32404095],\n",
-       "       [ 0.58000326,  0.41999674],\n",
-       "       [ 0.65313405,  0.34686592],\n",
-       "       [ 0.65428513,  0.34571484]], dtype=float32)"
+       "array([[ 0.52606189,  0.47393814],\n",
+       "       [ 0.56090653,  0.43909347],\n",
+       "       [ 0.58122021,  0.41877982],\n",
+       "       [ 0.58913922,  0.41086078],\n",
+       "       [ 0.58016819,  0.41983184]], dtype=float32)"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -582,19 +847,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Adding a new callback to the model is straightforward. Below we show how to add a new score to the validation set."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Add area under the ROC (AUC) score"
+    "Adding a new callback to the model is straightforward. Below we show how to add a new callback that determines the area under the ROC (AUC) score."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 31,
    "metadata": {
     "collapsed": true
    },
@@ -613,7 +871,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 32,
    "metadata": {
     "collapsed": true
    },
@@ -636,14 +894,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 33,
+   "metadata": {},
    "outputs": [],
    "source": [
     "net = NeuralNetClassifier(\n",
-    "    MyModule,\n",
+    "    ClassifierModule,\n",
     "    max_epochs=20,\n",
     "    lr=0.1,\n",
     "    callbacks=[auc],\n",
@@ -659,7 +915,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -668,35 +924,35 @@
      "text": [
       "  epoch     AUC    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ------  ------------  -----------  ------------  ------\n",
-      "      1  \u001b[36m0.6722\u001b[0m        \u001b[32m0.6730\u001b[0m       \u001b[35m0.6100\u001b[0m        \u001b[31m0.6730\u001b[0m  0.0969\n",
-      "      2  \u001b[36m0.6990\u001b[0m        \u001b[32m0.6469\u001b[0m       \u001b[35m0.6650\u001b[0m        \u001b[31m0.6621\u001b[0m  0.0831\n",
-      "      3  \u001b[36m0.7084\u001b[0m        \u001b[32m0.6423\u001b[0m       0.6500        \u001b[31m0.6548\u001b[0m  0.0896\n",
-      "      4  \u001b[36m0.7171\u001b[0m        \u001b[32m0.6257\u001b[0m       \u001b[35m0.6700\u001b[0m        \u001b[31m0.6482\u001b[0m  0.0780\n",
-      "      5  \u001b[36m0.7255\u001b[0m        0.6308       \u001b[35m0.6750\u001b[0m        \u001b[31m0.6402\u001b[0m  0.0748\n",
-      "      6  \u001b[36m0.7358\u001b[0m        \u001b[32m0.6043\u001b[0m       0.6650        \u001b[31m0.6330\u001b[0m  0.0882\n",
-      "      7  \u001b[36m0.7402\u001b[0m        \u001b[32m0.5999\u001b[0m       \u001b[35m0.6950\u001b[0m        \u001b[31m0.6277\u001b[0m  0.0806\n",
-      "      8  \u001b[36m0.7443\u001b[0m        \u001b[32m0.5935\u001b[0m       \u001b[35m0.7100\u001b[0m        \u001b[31m0.6238\u001b[0m  0.0734\n",
-      "      9  \u001b[36m0.7527\u001b[0m        \u001b[32m0.5866\u001b[0m       0.7000        \u001b[31m0.6095\u001b[0m  0.0858\n",
-      "     10  \u001b[36m0.7607\u001b[0m        0.5904       0.7100        \u001b[31m0.6039\u001b[0m  0.0971\n",
-      "     11  0.7595        \u001b[32m0.5699\u001b[0m       \u001b[35m0.7250\u001b[0m        \u001b[31m0.6007\u001b[0m  0.1063\n",
-      "     12  0.7579        \u001b[32m0.5636\u001b[0m       0.7100        \u001b[31m0.5992\u001b[0m  0.1536\n",
-      "     13  \u001b[36m0.7656\u001b[0m        \u001b[32m0.5634\u001b[0m       0.7200        \u001b[31m0.5903\u001b[0m  0.0948\n",
-      "     14  \u001b[36m0.7715\u001b[0m        0.5687       \u001b[35m0.7350\u001b[0m        \u001b[31m0.5858\u001b[0m  0.0547\n",
-      "     15  \u001b[36m0.7760\u001b[0m        \u001b[32m0.5372\u001b[0m       0.7250        0.5866  0.0547\n",
-      "     16  \u001b[36m0.7788\u001b[0m        0.5490       \u001b[35m0.7400\u001b[0m        \u001b[31m0.5843\u001b[0m  0.0672\n",
-      "     17  \u001b[36m0.7856\u001b[0m        0.5461       0.7250        \u001b[31m0.5689\u001b[0m  0.0734\n",
-      "     18  \u001b[36m0.7881\u001b[0m        \u001b[32m0.5354\u001b[0m       0.7400        \u001b[31m0.5676\u001b[0m  0.0745\n",
-      "     19  0.7863        0.5433       0.7350        \u001b[31m0.5674\u001b[0m  0.0823\n",
-      "     20  0.7857        \u001b[32m0.5150\u001b[0m       \u001b[35m0.7450\u001b[0m        \u001b[31m0.5671\u001b[0m  0.0988\n"
+      "      1  \u001b[36m0.5558\u001b[0m        \u001b[32m0.7150\u001b[0m       \u001b[35m0.4950\u001b[0m        \u001b[31m0.6935\u001b[0m  0.1051\n",
+      "      2  \u001b[36m0.6040\u001b[0m        \u001b[32m0.6811\u001b[0m       \u001b[35m0.5100\u001b[0m        \u001b[31m0.6756\u001b[0m  0.0831\n",
+      "      3  \u001b[36m0.6170\u001b[0m        \u001b[32m0.6694\u001b[0m       \u001b[35m0.5350\u001b[0m        \u001b[31m0.6661\u001b[0m  0.0823\n",
+      "      4  \u001b[36m0.6295\u001b[0m        \u001b[32m0.6505\u001b[0m       \u001b[35m0.5950\u001b[0m        \u001b[31m0.6557\u001b[0m  0.0733\n",
+      "      5  \u001b[36m0.6478\u001b[0m        \u001b[32m0.6447\u001b[0m       \u001b[35m0.6250\u001b[0m        \u001b[31m0.6457\u001b[0m  0.0718\n",
+      "      6  \u001b[36m0.6578\u001b[0m        \u001b[32m0.6389\u001b[0m       \u001b[35m0.6300\u001b[0m        \u001b[31m0.6359\u001b[0m  0.0661\n",
+      "      7  \u001b[36m0.6692\u001b[0m        \u001b[32m0.6282\u001b[0m       \u001b[35m0.6350\u001b[0m        \u001b[31m0.6277\u001b[0m  0.0710\n",
+      "      8  \u001b[36m0.6897\u001b[0m        \u001b[32m0.6159\u001b[0m       \u001b[35m0.6600\u001b[0m        \u001b[31m0.6172\u001b[0m  0.0581\n",
+      "      9  \u001b[36m0.7035\u001b[0m        \u001b[32m0.6085\u001b[0m       \u001b[35m0.6800\u001b[0m        \u001b[31m0.6096\u001b[0m  0.0576\n",
+      "     10  \u001b[36m0.7219\u001b[0m        \u001b[32m0.5993\u001b[0m       0.6800        \u001b[31m0.5996\u001b[0m  0.0628\n",
+      "     11  \u001b[36m0.7322\u001b[0m        \u001b[32m0.5950\u001b[0m       \u001b[35m0.6850\u001b[0m        \u001b[31m0.5941\u001b[0m  0.1337\n",
+      "     12  \u001b[36m0.7417\u001b[0m        \u001b[32m0.5813\u001b[0m       0.6850        \u001b[31m0.5869\u001b[0m  0.0624\n",
+      "     13  \u001b[36m0.7443\u001b[0m        0.5853       \u001b[35m0.6900\u001b[0m        \u001b[31m0.5815\u001b[0m  0.0996\n",
+      "     14  \u001b[36m0.7542\u001b[0m        \u001b[32m0.5756\u001b[0m       \u001b[35m0.6950\u001b[0m        \u001b[31m0.5755\u001b[0m  0.0680\n",
+      "     15  \u001b[36m0.7626\u001b[0m        \u001b[32m0.5601\u001b[0m       \u001b[35m0.7150\u001b[0m        \u001b[31m0.5692\u001b[0m  0.1486\n",
+      "     16  \u001b[36m0.7723\u001b[0m        \u001b[32m0.5455\u001b[0m       0.7150        \u001b[31m0.5604\u001b[0m  0.0952\n",
+      "     17  \u001b[36m0.7813\u001b[0m        \u001b[32m0.5390\u001b[0m       0.7100        \u001b[31m0.5517\u001b[0m  0.0573\n",
+      "     18  \u001b[36m0.7823\u001b[0m        \u001b[32m0.5310\u001b[0m       \u001b[35m0.7200\u001b[0m        \u001b[31m0.5475\u001b[0m  0.1085\n",
+      "     19  \u001b[36m0.7850\u001b[0m        0.5432       \u001b[35m0.7250\u001b[0m        \u001b[31m0.5445\u001b[0m  0.1888\n",
+      "     20  0.7847        0.5441       \u001b[35m0.7300\u001b[0m        0.5449  0.2138\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<skorch.net.NeuralNetClassifier at 0x7fb8c81b7630>"
+       "<skorch.net.NeuralNetClassifier at 0x7f8a98069438>"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -709,106 +965,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Writing your own callbacks"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Writing your own callbacks is also straightforward. Just remember these rules:\n",
-    "* They should inherit from `skorch.callbacks.Callback`.\n",
-    "* They should implement at least one of the `on_`-methods provided by the parent class (e.g. `on_batch_begin` or `on_epoch_end`).\n",
-    "* As argument, the `on_`-methods first get the `NeuralNet` instance, and, where appropriate, the local data (e.g. the data from the current batch). The method should also have `**kwargs` in the signature for potentially unused arguments."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here is an example of a callback that saves the model if the validation loss has improved."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "from skorch.callbacks import Callback\n",
-    "\n",
-    "\n",
-    "class Checkpoint(Callback):\n",
-    "    def __init__(self, file_name):\n",
-    "        self.file_name = file_name\n",
-    "\n",
-    "    def on_epoch_end(self, net, **kwargs):\n",
-    "        # check if valid accuracy of most recent epoch is the best so far\n",
-    "        if net.history[-1, 'valid_acc_best']:\n",
-    "            print(\"Save model to {}.\".format(self.file_name))\n",
-    "            net.save_params(self.file_name)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "net = NeuralNetClassifier(\n",
-    "    MyModule,\n",
-    "    max_epochs=10,\n",
-    "    callbacks=[auc, Checkpoint(file_name)],\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Save model to /tmp/mymodel.pkl.\n",
-      "  epoch     AUC    train_loss    valid_acc    valid_loss     dur\n",
-      "-------  ------  ------------  -----------  ------------  ------\n",
-      "      1  \u001b[36m0.5598\u001b[0m        \u001b[32m0.6962\u001b[0m       \u001b[35m0.5500\u001b[0m        \u001b[31m0.6894\u001b[0m  0.0941\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "      2  \u001b[36m0.5648\u001b[0m        \u001b[32m0.6905\u001b[0m       \u001b[35m0.5550\u001b[0m        \u001b[31m0.6889\u001b[0m  0.0619\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "      3  \u001b[36m0.5716\u001b[0m        0.6910       \u001b[35m0.5600\u001b[0m        \u001b[31m0.6883\u001b[0m  0.1134\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "      4  \u001b[36m0.5773\u001b[0m        \u001b[32m0.6904\u001b[0m       \u001b[35m0.5650\u001b[0m        \u001b[31m0.6878\u001b[0m  0.0817\n",
-      "      5  \u001b[36m0.5810\u001b[0m        0.6920       0.5650        \u001b[31m0.6873\u001b[0m  0.0709\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "      6  \u001b[36m0.5880\u001b[0m        \u001b[32m0.6889\u001b[0m       \u001b[35m0.5700\u001b[0m        \u001b[31m0.6867\u001b[0m  0.1115\n",
-      "      7  \u001b[36m0.5904\u001b[0m        0.6923       0.5600        \u001b[31m0.6862\u001b[0m  0.0659\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "      8  \u001b[36m0.5912\u001b[0m        \u001b[32m0.6838\u001b[0m       \u001b[35m0.5750\u001b[0m        \u001b[31m0.6858\u001b[0m  0.0948\n",
-      "Save model to /tmp/mymodel.pkl.\n",
-      "      9  \u001b[36m0.5957\u001b[0m        0.6881       \u001b[35m0.5800\u001b[0m        \u001b[31m0.6853\u001b[0m  0.0810\n",
-      "     10  \u001b[36m0.6012\u001b[0m        0.6891       0.5800        \u001b[31m0.6849\u001b[0m  0.0949\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<skorch.net.NeuralNetClassifier at 0x7fb938c157f0>"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "net.fit(X, y)"
+    "For information on how to write custom callbacks, have a look at the *Advanced_Usage* notebook."
    ]
   },
   {
@@ -850,7 +1007,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -881,7 +1038,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 36,
    "metadata": {
     "collapsed": true
    },
@@ -892,14 +1049,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 37,
+   "metadata": {},
    "outputs": [],
    "source": [
     "net = NeuralNetClassifier(\n",
-    "    MyModule,\n",
+    "    ClassifierModule,\n",
     "    max_epochs=20,\n",
     "    lr=0.1,\n",
     "    verbose=0,\n",
@@ -909,7 +1064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 38,
    "metadata": {
     "collapsed": true
    },
@@ -925,7 +1080,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 39,
    "metadata": {
     "collapsed": true
    },
@@ -936,7 +1091,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -945,7 +1100,7 @@
      "text": [
       "Fitting 3 folds for each of 16 candidates, totalling 48 fits\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   1.1s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   1.2s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False \n"
      ]
     },
@@ -953,26 +1108,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    1.1s remaining:    0.0s\n"
+      "[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    1.2s remaining:    0.0s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False \n",
       "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   0.8s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True \n",
       "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   0.8s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   1.0s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   1.0s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False \n",
       "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   0.9s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True \n",
@@ -980,37 +1135,37 @@
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True \n",
       "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   0.9s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   1.0s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   1.0s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   1.0s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
       "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   1.0s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
       "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
+      "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   1.1s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
       "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   1.0s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   0.9s\n",
-      "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   1.1s\n",
+      "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   1.9s\n",
+      "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   0.8s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
       "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   1.0s\n",
-      "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   0.8s\n",
-      "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   0.8s\n",
+      "[CV] lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False \n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False \n",
       "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   1.0s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
-      "[CV] lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=True \n",
       "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=True \n",
@@ -1022,58 +1177,58 @@
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False \n",
       "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   1.0s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True \n",
       "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   1.0s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   0.9s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   1.2s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   1.0s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   1.4s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   1.1s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
-      "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   1.1s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
       "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.8s\n",
-      "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   0.9s\n",
+      "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
       "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
       "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   1.0s\n",
+      "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   1.0s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   1.0s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   1.0s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   0.9s\n"
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   1.1s\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[Parallel(n_jobs=1)]: Done  48 out of  48 | elapsed:   45.8s finished\n"
+      "[Parallel(n_jobs=1)]: Done  48 out of  48 | elapsed:   48.2s finished\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "GridSearchCV(cv=3, error_score='raise',\n",
-       "       estimator=<skorch.net.NeuralNetClassifier object at 0x7fb8c8176860>,\n",
+       "       estimator=<skorch.net.NeuralNetClassifier object at 0x7f8a98079f98>,\n",
        "       fit_params=None, iid=True, n_jobs=1,\n",
        "       param_grid={'lr': [0.05, 0.1], 'module__num_units': [10, 20], 'module__dropout': [0, 0.5], 'optim__nesterov': [False, True]},\n",
        "       pre_dispatch='2*n_jobs', refit=False, return_train_score=True,\n",
        "       scoring='accuracy', verbose=2)"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1084,7 +1239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 41,
    "metadata": {
     "scrolled": true
    },
@@ -1093,7 +1248,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.856 {'lr': 0.1, 'module__dropout': 0, 'module__num_units': 20, 'optim__nesterov': True}\n"
+      "0.851 {'lr': 0.1, 'module__dropout': 0, 'module__num_units': 20, 'optim__nesterov': True}\n"
      ]
     }
    ],

--- a/notebooks/Basic_Usage.ipynb
+++ b/notebooks/Basic_Usage.ipynb
@@ -22,30 +22,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "import torch\n",
-    "from torch import nn\n",
-    "import torch.nn.functional as F"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "torch.manual_seed(0);"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -75,6 +51,30 @@
     "* [Grid search](#Usage-with-sklearn-GridSearchCV)\n",
     "  * [Special prefixes](#Special-prefixes)\n",
     "  * [Performing a grid search](#Performing-a-grid-search)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch import nn\n",
+    "import torch.nn.functional as F"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "torch.manual_seed(0);"
    ]
   },
   {
@@ -253,32 +253,32 @@
      "text": [
       "  epoch    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ------------  -----------  ------------  ------\n",
-      "      1        \u001b[36m0.7111\u001b[0m       \u001b[32m0.5100\u001b[0m        \u001b[35m0.6894\u001b[0m  0.1124\n",
-      "      2        \u001b[36m0.6928\u001b[0m       \u001b[32m0.5500\u001b[0m        \u001b[35m0.6803\u001b[0m  0.0762\n",
-      "      3        \u001b[36m0.6833\u001b[0m       \u001b[32m0.5650\u001b[0m        \u001b[35m0.6741\u001b[0m  0.0615\n",
-      "      4        \u001b[36m0.6763\u001b[0m       \u001b[32m0.5850\u001b[0m        \u001b[35m0.6674\u001b[0m  0.0626\n",
-      "      5        \u001b[36m0.6727\u001b[0m       \u001b[32m0.6450\u001b[0m        \u001b[35m0.6616\u001b[0m  0.0629\n",
-      "      6        \u001b[36m0.6606\u001b[0m       \u001b[32m0.6600\u001b[0m        \u001b[35m0.6536\u001b[0m  0.1240\n",
-      "      7        \u001b[36m0.6560\u001b[0m       0.6600        \u001b[35m0.6443\u001b[0m  0.0528\n",
-      "      8        \u001b[36m0.6427\u001b[0m       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6354\u001b[0m  0.0604\n",
-      "      9        \u001b[36m0.6300\u001b[0m       \u001b[32m0.6800\u001b[0m        \u001b[35m0.6264\u001b[0m  0.0695\n",
-      "     10        \u001b[36m0.6289\u001b[0m       0.6800        \u001b[35m0.6189\u001b[0m  0.1094\n",
-      "     11        \u001b[36m0.6241\u001b[0m       \u001b[32m0.7150\u001b[0m        \u001b[35m0.6114\u001b[0m  0.0818\n",
-      "     12        \u001b[36m0.6132\u001b[0m       0.7150        \u001b[35m0.6017\u001b[0m  0.0606\n",
-      "     13        \u001b[36m0.5950\u001b[0m       \u001b[32m0.7350\u001b[0m        \u001b[35m0.5902\u001b[0m  0.0570\n",
-      "     14        \u001b[36m0.5914\u001b[0m       0.7200        \u001b[35m0.5831\u001b[0m  0.0590\n",
-      "     15        \u001b[36m0.5784\u001b[0m       0.7300        \u001b[35m0.5733\u001b[0m  0.0553\n",
-      "     16        0.5816       \u001b[32m0.7400\u001b[0m        \u001b[35m0.5665\u001b[0m  0.0612\n",
-      "     17        \u001b[36m0.5766\u001b[0m       \u001b[32m0.7450\u001b[0m        \u001b[35m0.5616\u001b[0m  0.0582\n",
-      "     18        \u001b[36m0.5636\u001b[0m       0.7450        \u001b[35m0.5559\u001b[0m  0.0585\n",
-      "     19        \u001b[36m0.5517\u001b[0m       0.7350        \u001b[35m0.5527\u001b[0m  0.0607\n",
-      "     20        0.5570       0.7350        \u001b[35m0.5492\u001b[0m  0.0585\n"
+      "      1        \u001b[36m0.7111\u001b[0m       \u001b[32m0.5100\u001b[0m        \u001b[35m0.6894\u001b[0m  0.1407\n",
+      "      2        \u001b[36m0.6928\u001b[0m       \u001b[32m0.5500\u001b[0m        \u001b[35m0.6803\u001b[0m  0.0775\n",
+      "      3        \u001b[36m0.6833\u001b[0m       \u001b[32m0.5650\u001b[0m        \u001b[35m0.6741\u001b[0m  0.0726\n",
+      "      4        \u001b[36m0.6763\u001b[0m       \u001b[32m0.5850\u001b[0m        \u001b[35m0.6674\u001b[0m  0.0670\n",
+      "      5        \u001b[36m0.6727\u001b[0m       \u001b[32m0.6450\u001b[0m        \u001b[35m0.6616\u001b[0m  0.0656\n",
+      "      6        \u001b[36m0.6606\u001b[0m       \u001b[32m0.6600\u001b[0m        \u001b[35m0.6536\u001b[0m  0.0969\n",
+      "      7        \u001b[36m0.6560\u001b[0m       0.6600        \u001b[35m0.6443\u001b[0m  0.0625\n",
+      "      8        \u001b[36m0.6427\u001b[0m       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6354\u001b[0m  0.0646\n",
+      "      9        \u001b[36m0.6300\u001b[0m       \u001b[32m0.6800\u001b[0m        \u001b[35m0.6264\u001b[0m  0.0758\n",
+      "     10        \u001b[36m0.6289\u001b[0m       0.6800        \u001b[35m0.6189\u001b[0m  0.1337\n",
+      "     11        \u001b[36m0.6241\u001b[0m       \u001b[32m0.7150\u001b[0m        \u001b[35m0.6114\u001b[0m  0.0667\n",
+      "     12        \u001b[36m0.6132\u001b[0m       0.7150        \u001b[35m0.6017\u001b[0m  0.1059\n",
+      "     13        \u001b[36m0.5950\u001b[0m       \u001b[32m0.7350\u001b[0m        \u001b[35m0.5902\u001b[0m  0.0837\n",
+      "     14        \u001b[36m0.5914\u001b[0m       0.7200        \u001b[35m0.5831\u001b[0m  0.0692\n",
+      "     15        \u001b[36m0.5784\u001b[0m       0.7300        \u001b[35m0.5733\u001b[0m  0.0538\n",
+      "     16        0.5816       \u001b[32m0.7400\u001b[0m        \u001b[35m0.5665\u001b[0m  0.0567\n",
+      "     17        \u001b[36m0.5766\u001b[0m       \u001b[32m0.7450\u001b[0m        \u001b[35m0.5616\u001b[0m  0.0643\n",
+      "     18        \u001b[36m0.5636\u001b[0m       0.7450        \u001b[35m0.5559\u001b[0m  0.0517\n",
+      "     19        \u001b[36m0.5517\u001b[0m       0.7350        \u001b[35m0.5527\u001b[0m  0.0521\n",
+      "     20        0.5570       0.7350        \u001b[35m0.5492\u001b[0m  0.0580\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<skorch.net.NeuralNetClassifier at 0x7f8a9d2b0a20>"
+       "<skorch.net.NeuralNetClassifier at 0x7ff019ec0908>"
       ]
      },
      "execution_count": 9,
@@ -490,7 +490,9 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "net_regr = NeuralNetRegressor(\n",
@@ -512,32 +514,32 @@
      "text": [
       "  epoch    train_loss    valid_loss     dur\n",
       "-------  ------------  ------------  ------\n",
-      "      1        \u001b[36m4.6084\u001b[0m        \u001b[32m3.8757\u001b[0m  0.0518\n",
-      "      2        \u001b[36m3.9371\u001b[0m        \u001b[32m2.2167\u001b[0m  0.0485\n",
-      "      3        \u001b[36m1.0512\u001b[0m        \u001b[32m0.2644\u001b[0m  0.0378\n",
-      "      4        \u001b[36m0.2770\u001b[0m        0.3933  0.0340\n",
-      "      5        0.3052        \u001b[32m0.1762\u001b[0m  0.0340\n",
-      "      6        \u001b[36m0.1650\u001b[0m        \u001b[32m0.1601\u001b[0m  0.0368\n",
-      "      7        \u001b[36m0.1115\u001b[0m        \u001b[32m0.0990\u001b[0m  0.0322\n",
-      "      8        \u001b[36m0.1067\u001b[0m        0.1418  0.0360\n",
-      "      9        \u001b[36m0.0907\u001b[0m        \u001b[32m0.0828\u001b[0m  0.0355\n",
-      "     10        \u001b[36m0.0792\u001b[0m        \u001b[32m0.0760\u001b[0m  0.0373\n",
-      "     11        \u001b[36m0.0470\u001b[0m        \u001b[32m0.0529\u001b[0m  0.0380\n",
-      "     12        0.0500        \u001b[32m0.0426\u001b[0m  0.0375\n",
-      "     13        \u001b[36m0.0266\u001b[0m        \u001b[32m0.0365\u001b[0m  0.0350\n",
-      "     14        0.0346        \u001b[32m0.0255\u001b[0m  0.0410\n",
-      "     15        \u001b[36m0.0170\u001b[0m        0.0269  0.0421\n",
-      "     16        0.0253        \u001b[32m0.0170\u001b[0m  0.0406\n",
-      "     17        \u001b[36m0.0123\u001b[0m        0.0213  0.0379\n",
-      "     18        0.0197        \u001b[32m0.0122\u001b[0m  0.0338\n",
-      "     19        \u001b[36m0.0096\u001b[0m        0.0177  0.0401\n",
-      "     20        0.0166        \u001b[32m0.0104\u001b[0m  0.0396\n"
+      "      1        \u001b[36m4.6084\u001b[0m        \u001b[32m3.8757\u001b[0m  0.0557\n",
+      "      2        \u001b[36m3.9371\u001b[0m        \u001b[32m2.2167\u001b[0m  0.0525\n",
+      "      3        \u001b[36m1.0512\u001b[0m        \u001b[32m0.2644\u001b[0m  0.0349\n",
+      "      4        \u001b[36m0.2770\u001b[0m        0.3933  0.0363\n",
+      "      5        0.3052        \u001b[32m0.1762\u001b[0m  0.0328\n",
+      "      6        \u001b[36m0.1650\u001b[0m        \u001b[32m0.1601\u001b[0m  0.0324\n",
+      "      7        \u001b[36m0.1115\u001b[0m        \u001b[32m0.0990\u001b[0m  0.0327\n",
+      "      8        \u001b[36m0.1067\u001b[0m        0.1418  0.0387\n",
+      "      9        \u001b[36m0.0907\u001b[0m        \u001b[32m0.0828\u001b[0m  0.0373\n",
+      "     10        \u001b[36m0.0792\u001b[0m        \u001b[32m0.0760\u001b[0m  0.0381\n",
+      "     11        \u001b[36m0.0470\u001b[0m        \u001b[32m0.0529\u001b[0m  0.0389\n",
+      "     12        0.0500        \u001b[32m0.0426\u001b[0m  0.0387\n",
+      "     13        \u001b[36m0.0266\u001b[0m        \u001b[32m0.0365\u001b[0m  0.0362\n",
+      "     14        0.0346        \u001b[32m0.0255\u001b[0m  0.0398\n",
+      "     15        \u001b[36m0.0170\u001b[0m        0.0269  0.0374\n",
+      "     16        0.0253        \u001b[32m0.0170\u001b[0m  0.0365\n",
+      "     17        \u001b[36m0.0123\u001b[0m        0.0213  0.0382\n",
+      "     18        0.0197        \u001b[32m0.0122\u001b[0m  0.0392\n",
+      "     19        \u001b[36m0.0096\u001b[0m        0.0177  0.0385\n",
+      "     20        0.0166        \u001b[32m0.0104\u001b[0m  0.0424\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<skorch.net.NeuralNetRegressor at 0x7f8a980a76d8>"
+       "<skorch.net.NeuralNetRegressor at 0x7ff018084518>"
       ]
      },
      "execution_count": 18,
@@ -692,7 +694,9 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# first initialize the model\n",
@@ -766,33 +770,33 @@
       "Re-initializing module!\n",
       "  epoch    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ------------  -----------  ------------  ------\n",
-      "      1        \u001b[36m0.6982\u001b[0m       \u001b[32m0.4950\u001b[0m        \u001b[35m0.6960\u001b[0m  0.0959\n",
-      "      2        \u001b[36m0.6943\u001b[0m       \u001b[32m0.5300\u001b[0m        \u001b[35m0.6943\u001b[0m  0.0743\n",
-      "      3        \u001b[36m0.6934\u001b[0m       0.5100        \u001b[35m0.6927\u001b[0m  0.0640\n",
-      "      4        \u001b[36m0.6924\u001b[0m       0.5150        \u001b[35m0.6912\u001b[0m  0.0714\n",
-      "      5        0.6931       0.5100        \u001b[35m0.6899\u001b[0m  0.0622\n",
-      "      6        \u001b[36m0.6897\u001b[0m       \u001b[32m0.5350\u001b[0m        \u001b[35m0.6891\u001b[0m  0.0628\n",
-      "      7        \u001b[36m0.6884\u001b[0m       \u001b[32m0.5450\u001b[0m        \u001b[35m0.6877\u001b[0m  0.0665\n",
-      "      8        \u001b[36m0.6821\u001b[0m       \u001b[32m0.5650\u001b[0m        \u001b[35m0.6856\u001b[0m  0.0761\n",
-      "      9        0.6854       \u001b[32m0.5800\u001b[0m        \u001b[35m0.6835\u001b[0m  0.0648\n",
-      "     10        \u001b[36m0.6801\u001b[0m       \u001b[32m0.6000\u001b[0m        \u001b[35m0.6813\u001b[0m  0.0886\n",
-      "     11        \u001b[36m0.6781\u001b[0m       \u001b[32m0.6150\u001b[0m        \u001b[35m0.6786\u001b[0m  0.0804\n",
-      "     12        \u001b[36m0.6758\u001b[0m       \u001b[32m0.6200\u001b[0m        \u001b[35m0.6757\u001b[0m  0.0838\n",
-      "     13        \u001b[36m0.6715\u001b[0m       \u001b[32m0.6250\u001b[0m        \u001b[35m0.6723\u001b[0m  0.0527\n",
-      "     14        \u001b[36m0.6711\u001b[0m       \u001b[32m0.6350\u001b[0m        \u001b[35m0.6686\u001b[0m  0.0849\n",
-      "     15        \u001b[36m0.6687\u001b[0m       0.6350        \u001b[35m0.6649\u001b[0m  0.0538\n",
-      "     16        \u001b[36m0.6633\u001b[0m       \u001b[32m0.6500\u001b[0m        \u001b[35m0.6604\u001b[0m  0.0564\n",
-      "     17        0.6634       0.6500        \u001b[35m0.6556\u001b[0m  0.1039\n",
-      "     18        \u001b[36m0.6559\u001b[0m       0.6500        \u001b[35m0.6490\u001b[0m  0.1359\n",
-      "     19        \u001b[36m0.6482\u001b[0m       \u001b[32m0.6550\u001b[0m        \u001b[35m0.6430\u001b[0m  0.0622\n",
-      "     20        0.6498       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6375\u001b[0m  0.0802\n"
+      "      1        \u001b[36m0.6982\u001b[0m       \u001b[32m0.4950\u001b[0m        \u001b[35m0.6960\u001b[0m  0.1439\n",
+      "      2        \u001b[36m0.6943\u001b[0m       \u001b[32m0.5300\u001b[0m        \u001b[35m0.6943\u001b[0m  0.1277\n",
+      "      3        \u001b[36m0.6934\u001b[0m       0.5100        \u001b[35m0.6927\u001b[0m  0.0856\n",
+      "      4        \u001b[36m0.6924\u001b[0m       0.5150        \u001b[35m0.6912\u001b[0m  0.0682\n",
+      "      5        0.6931       0.5100        \u001b[35m0.6899\u001b[0m  0.0555\n",
+      "      6        \u001b[36m0.6897\u001b[0m       \u001b[32m0.5350\u001b[0m        \u001b[35m0.6891\u001b[0m  0.0640\n",
+      "      7        \u001b[36m0.6884\u001b[0m       \u001b[32m0.5450\u001b[0m        \u001b[35m0.6877\u001b[0m  0.0596\n",
+      "      8        \u001b[36m0.6821\u001b[0m       \u001b[32m0.5650\u001b[0m        \u001b[35m0.6856\u001b[0m  0.0535\n",
+      "      9        0.6854       \u001b[32m0.5800\u001b[0m        \u001b[35m0.6835\u001b[0m  0.0585\n",
+      "     10        \u001b[36m0.6801\u001b[0m       \u001b[32m0.6000\u001b[0m        \u001b[35m0.6813\u001b[0m  0.0571\n",
+      "     11        \u001b[36m0.6781\u001b[0m       \u001b[32m0.6150\u001b[0m        \u001b[35m0.6786\u001b[0m  0.0492\n",
+      "     12        \u001b[36m0.6758\u001b[0m       \u001b[32m0.6200\u001b[0m        \u001b[35m0.6757\u001b[0m  0.0435\n",
+      "     13        \u001b[36m0.6715\u001b[0m       \u001b[32m0.6250\u001b[0m        \u001b[35m0.6723\u001b[0m  0.0570\n",
+      "     14        \u001b[36m0.6711\u001b[0m       \u001b[32m0.6350\u001b[0m        \u001b[35m0.6686\u001b[0m  0.0557\n",
+      "     15        \u001b[36m0.6687\u001b[0m       0.6350        \u001b[35m0.6649\u001b[0m  0.0439\n",
+      "     16        \u001b[36m0.6633\u001b[0m       \u001b[32m0.6500\u001b[0m        \u001b[35m0.6604\u001b[0m  0.0727\n",
+      "     17        0.6634       0.6500        \u001b[35m0.6556\u001b[0m  0.0745\n",
+      "     18        \u001b[36m0.6559\u001b[0m       0.6500        \u001b[35m0.6490\u001b[0m  0.0600\n",
+      "     19        \u001b[36m0.6482\u001b[0m       \u001b[32m0.6550\u001b[0m        \u001b[35m0.6430\u001b[0m  0.1206\n",
+      "     20        0.6498       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6375\u001b[0m  0.0864\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "Pipeline(memory=None,\n",
-       "     steps=[('scale', StandardScaler(copy=True, with_mean=True, with_std=True)), ('net', <skorch.net.NeuralNetClassifier object at 0x7f8a9d2b0a20>)])"
+       "     steps=[('scale', StandardScaler(copy=True, with_mean=True, with_std=True)), ('net', <skorch.net.NeuralNetClassifier object at 0x7ff019ec0908>)])"
       ]
      },
      "execution_count": 29,
@@ -895,7 +899,9 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "net = NeuralNetClassifier(\n",
@@ -924,32 +930,32 @@
      "text": [
       "  epoch     AUC    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ------  ------------  -----------  ------------  ------\n",
-      "      1  \u001b[36m0.5558\u001b[0m        \u001b[32m0.7150\u001b[0m       \u001b[35m0.4950\u001b[0m        \u001b[31m0.6935\u001b[0m  0.1051\n",
-      "      2  \u001b[36m0.6040\u001b[0m        \u001b[32m0.6811\u001b[0m       \u001b[35m0.5100\u001b[0m        \u001b[31m0.6756\u001b[0m  0.0831\n",
-      "      3  \u001b[36m0.6170\u001b[0m        \u001b[32m0.6694\u001b[0m       \u001b[35m0.5350\u001b[0m        \u001b[31m0.6661\u001b[0m  0.0823\n",
-      "      4  \u001b[36m0.6295\u001b[0m        \u001b[32m0.6505\u001b[0m       \u001b[35m0.5950\u001b[0m        \u001b[31m0.6557\u001b[0m  0.0733\n",
-      "      5  \u001b[36m0.6478\u001b[0m        \u001b[32m0.6447\u001b[0m       \u001b[35m0.6250\u001b[0m        \u001b[31m0.6457\u001b[0m  0.0718\n",
-      "      6  \u001b[36m0.6578\u001b[0m        \u001b[32m0.6389\u001b[0m       \u001b[35m0.6300\u001b[0m        \u001b[31m0.6359\u001b[0m  0.0661\n",
-      "      7  \u001b[36m0.6692\u001b[0m        \u001b[32m0.6282\u001b[0m       \u001b[35m0.6350\u001b[0m        \u001b[31m0.6277\u001b[0m  0.0710\n",
-      "      8  \u001b[36m0.6897\u001b[0m        \u001b[32m0.6159\u001b[0m       \u001b[35m0.6600\u001b[0m        \u001b[31m0.6172\u001b[0m  0.0581\n",
-      "      9  \u001b[36m0.7035\u001b[0m        \u001b[32m0.6085\u001b[0m       \u001b[35m0.6800\u001b[0m        \u001b[31m0.6096\u001b[0m  0.0576\n",
-      "     10  \u001b[36m0.7219\u001b[0m        \u001b[32m0.5993\u001b[0m       0.6800        \u001b[31m0.5996\u001b[0m  0.0628\n",
-      "     11  \u001b[36m0.7322\u001b[0m        \u001b[32m0.5950\u001b[0m       \u001b[35m0.6850\u001b[0m        \u001b[31m0.5941\u001b[0m  0.1337\n",
-      "     12  \u001b[36m0.7417\u001b[0m        \u001b[32m0.5813\u001b[0m       0.6850        \u001b[31m0.5869\u001b[0m  0.0624\n",
-      "     13  \u001b[36m0.7443\u001b[0m        0.5853       \u001b[35m0.6900\u001b[0m        \u001b[31m0.5815\u001b[0m  0.0996\n",
-      "     14  \u001b[36m0.7542\u001b[0m        \u001b[32m0.5756\u001b[0m       \u001b[35m0.6950\u001b[0m        \u001b[31m0.5755\u001b[0m  0.0680\n",
-      "     15  \u001b[36m0.7626\u001b[0m        \u001b[32m0.5601\u001b[0m       \u001b[35m0.7150\u001b[0m        \u001b[31m0.5692\u001b[0m  0.1486\n",
-      "     16  \u001b[36m0.7723\u001b[0m        \u001b[32m0.5455\u001b[0m       0.7150        \u001b[31m0.5604\u001b[0m  0.0952\n",
-      "     17  \u001b[36m0.7813\u001b[0m        \u001b[32m0.5390\u001b[0m       0.7100        \u001b[31m0.5517\u001b[0m  0.0573\n",
-      "     18  \u001b[36m0.7823\u001b[0m        \u001b[32m0.5310\u001b[0m       \u001b[35m0.7200\u001b[0m        \u001b[31m0.5475\u001b[0m  0.1085\n",
-      "     19  \u001b[36m0.7850\u001b[0m        0.5432       \u001b[35m0.7250\u001b[0m        \u001b[31m0.5445\u001b[0m  0.1888\n",
-      "     20  0.7847        0.5441       \u001b[35m0.7300\u001b[0m        0.5449  0.2138\n"
+      "      1  \u001b[36m0.5558\u001b[0m        \u001b[32m0.7150\u001b[0m       \u001b[35m0.4950\u001b[0m        \u001b[31m0.6935\u001b[0m  0.0745\n",
+      "      2  \u001b[36m0.6040\u001b[0m        \u001b[32m0.6811\u001b[0m       \u001b[35m0.5100\u001b[0m        \u001b[31m0.6756\u001b[0m  0.0589\n",
+      "      3  \u001b[36m0.6170\u001b[0m        \u001b[32m0.6694\u001b[0m       \u001b[35m0.5350\u001b[0m        \u001b[31m0.6661\u001b[0m  0.0555\n",
+      "      4  \u001b[36m0.6295\u001b[0m        \u001b[32m0.6505\u001b[0m       \u001b[35m0.5950\u001b[0m        \u001b[31m0.6557\u001b[0m  0.0568\n",
+      "      5  \u001b[36m0.6478\u001b[0m        \u001b[32m0.6447\u001b[0m       \u001b[35m0.6250\u001b[0m        \u001b[31m0.6457\u001b[0m  0.0577\n",
+      "      6  \u001b[36m0.6578\u001b[0m        \u001b[32m0.6389\u001b[0m       \u001b[35m0.6300\u001b[0m        \u001b[31m0.6359\u001b[0m  0.0550\n",
+      "      7  \u001b[36m0.6692\u001b[0m        \u001b[32m0.6282\u001b[0m       \u001b[35m0.6350\u001b[0m        \u001b[31m0.6277\u001b[0m  0.0557\n",
+      "      8  \u001b[36m0.6897\u001b[0m        \u001b[32m0.6159\u001b[0m       \u001b[35m0.6600\u001b[0m        \u001b[31m0.6172\u001b[0m  0.0674\n",
+      "      9  \u001b[36m0.7035\u001b[0m        \u001b[32m0.6085\u001b[0m       \u001b[35m0.6800\u001b[0m        \u001b[31m0.6096\u001b[0m  0.0640\n",
+      "     10  \u001b[36m0.7219\u001b[0m        \u001b[32m0.5993\u001b[0m       0.6800        \u001b[31m0.5996\u001b[0m  0.0658\n",
+      "     11  \u001b[36m0.7322\u001b[0m        \u001b[32m0.5950\u001b[0m       \u001b[35m0.6850\u001b[0m        \u001b[31m0.5941\u001b[0m  0.2349\n",
+      "     12  \u001b[36m0.7417\u001b[0m        \u001b[32m0.5813\u001b[0m       0.6850        \u001b[31m0.5869\u001b[0m  0.0439\n",
+      "     13  \u001b[36m0.7443\u001b[0m        0.5853       \u001b[35m0.6900\u001b[0m        \u001b[31m0.5815\u001b[0m  0.0488\n",
+      "     14  \u001b[36m0.7542\u001b[0m        \u001b[32m0.5756\u001b[0m       \u001b[35m0.6950\u001b[0m        \u001b[31m0.5755\u001b[0m  0.0768\n",
+      "     15  \u001b[36m0.7626\u001b[0m        \u001b[32m0.5601\u001b[0m       \u001b[35m0.7150\u001b[0m        \u001b[31m0.5692\u001b[0m  0.0564\n",
+      "     16  \u001b[36m0.7723\u001b[0m        \u001b[32m0.5455\u001b[0m       0.7150        \u001b[31m0.5604\u001b[0m  0.0873\n",
+      "     17  \u001b[36m0.7813\u001b[0m        \u001b[32m0.5390\u001b[0m       0.7100        \u001b[31m0.5517\u001b[0m  0.0543\n",
+      "     18  \u001b[36m0.7823\u001b[0m        \u001b[32m0.5310\u001b[0m       \u001b[35m0.7200\u001b[0m        \u001b[31m0.5475\u001b[0m  0.0684\n",
+      "     19  \u001b[36m0.7850\u001b[0m        0.5432       \u001b[35m0.7250\u001b[0m        \u001b[31m0.5445\u001b[0m  0.0730\n",
+      "     20  0.7847        0.5441       \u001b[35m0.7300\u001b[0m        0.5449  0.0640\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<skorch.net.NeuralNetClassifier at 0x7f8a98069438>"
+       "<skorch.net.NeuralNetClassifier at 0x7ff01805e5c0>"
       ]
      },
      "execution_count": 34,
@@ -1002,7 +1008,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In addition to the parameters prefixed by `module__`, you may access a couple of other attributes, such as those of the optimizer by using the `optim__` prefix (again, see below). All those special prefixes are stored in the `prefixes_` attribute:"
+    "In addition to the parameters prefixed by `module__`, you may access a couple of other attributes, such as those of the optimizer by using the `optimizer__` prefix (again, see below). All those special prefixes are stored in the `prefixes_` attribute:"
    ]
   },
   {
@@ -1033,7 +1039,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below we show how to perform a grid search over the learning rate (`lr`), the module's number of hidden units (`module__num_units`), the module's dropout rate (`module__dropout`), and whether the SGD optimizer should use Nesterov momentum or not (`optim__nesterov`)."
+    "Below we show how to perform a grid search over the learning rate (`lr`), the module's number of hidden units (`module__num_units`), the module's dropout rate (`module__dropout`), and whether the SGD optimizer should use Nesterov momentum or not (`optimizer__nesterov`)."
    ]
   },
   {
@@ -1050,7 +1056,9 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "net = NeuralNetClassifier(\n",
@@ -1058,7 +1066,7 @@
     "    max_epochs=20,\n",
     "    lr=0.1,\n",
     "    verbose=0,\n",
-    "    optim__momentum=0.9,\n",
+    "    optimizer__momentum=0.9,\n",
     ")"
    ]
   },
@@ -1074,7 +1082,7 @@
     "    'lr': [0.05, 0.1],\n",
     "    'module__num_units': [10, 20],\n",
     "    'module__dropout': [0, 0.5],\n",
-    "    'optim__nesterov': [False, True],\n",
+    "    'optimizer__nesterov': [False, True],\n",
     "}"
    ]
   },
@@ -1100,7 +1108,7 @@
      "text": [
       "Fitting 3 folds for each of 16 candidates, totalling 48 fits\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   1.2s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   1.0s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False \n"
      ]
     },
@@ -1108,120 +1116,120 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    1.2s remaining:    0.0s\n"
+      "[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    1.1s remaining:    0.0s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   1.0s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   1.2s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   0.8s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   1.7s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   2.2s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   0.8s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   1.1s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   1.0s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   1.0s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   1.1s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False \n",
       "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   0.9s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   0.7s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   0.8s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   1.0s\n",
-      "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   1.0s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   0.8s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
       "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   1.0s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
+      "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.8s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   1.0s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.8s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
-      "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   1.1s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.8s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
       "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   1.0s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   1.1s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   0.9s\n",
+      "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   0.9s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   1.9s\n",
-      "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   0.8s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   0.9s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
       "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   1.0s\n",
+      "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   1.0s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False \n",
       "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=True \n",
       "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   1.0s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=True \n",
       "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   1.0s\n",
-      "[CV] lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False \n",
       "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   1.0s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   0.7s\n",
+      "[CV] lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False \n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=False, total=   0.8s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True \n",
       "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   1.0s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   1.2s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   0.8s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   1.4s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optim__nesterov=True, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   1.1s\n",
-      "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
       "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.8s\n",
-      "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   1.1s\n",
-      "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.8s\n",
+      "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False \n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=False, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
       "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
+      "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.9s\n",
+      "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True \n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optim__nesterov=True, total=   0.8s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
       "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   1.0s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   1.0s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=False, total=   0.8s\n",
+      "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   0.8s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
       "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   0.9s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   0.9s\n",
-      "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   1.1s\n"
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optim__nesterov=True, total=   0.9s\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[Parallel(n_jobs=1)]: Done  48 out of  48 | elapsed:   48.2s finished\n"
+      "[Parallel(n_jobs=1)]: Done  48 out of  48 | elapsed:   45.6s finished\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "GridSearchCV(cv=3, error_score='raise',\n",
-       "       estimator=<skorch.net.NeuralNetClassifier object at 0x7f8a98079f98>,\n",
+       "       estimator=<skorch.net.NeuralNetClassifier object at 0x7ff018061208>,\n",
        "       fit_params=None, iid=True, n_jobs=1,\n",
        "       param_grid={'lr': [0.05, 0.1], 'module__num_units': [10, 20], 'module__dropout': [0, 0.5], 'optim__nesterov': [False, True]},\n",
        "       pre_dispatch='2*n_jobs', refit=False, return_train_score=True,\n",

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,4 @@
+# Notebooks
+
+* [Basic usage](https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/Basic_Usage.ipynb)
+* [Advanced usage](https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/Advanced_Usage.ipynb)

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1018,3 +1018,6 @@ class NeuralNetRegressor(NeuralNet):
         # this is actually a pylint bug:
         # https://github.com/PyCQA/pylint/issues/1085
         return super(NeuralNetRegressor, self).fit(X, y, **fit_params)
+
+    def predict(self, X):
+        return self.predict_proba(X)

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -704,3 +704,14 @@ class TestNeuralNetRegressor:
         assert exc.value.args[0] == (
             "The target data shouldn't be 1-dimensional; "
             "please reshape (e.g. y.reshape(-1, 1).")
+
+    def test_predict_predict_proba(self, net, data):
+        X = data[0]
+        y_pred = net.predict(X)
+
+        # predictions should not be all zeros
+        assert not np.allclose(y_pred, 0)
+
+        y_proba = net.predict_proba(X)
+        # predict and predict_proba should be identical for regression
+        assert np.allclose(y_pred, y_proba)


### PR DESCRIPTION
Mainly adds a regression task to the Basic_Usage notebook. I moved the "custom callbacks" section to an Advanced_Usage notebook, where we should put all the stuff that involves custom classes etc.

During the task, I discovered a bug in `NeuralNetRegressor`, which is fixed now.

This addresses phantom issue #77