### PR TITLE
params_for utility

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -20,6 +20,7 @@ from skorch.history import History
 from skorch.utils import get_dim
 from skorch.utils import to_numpy
 from skorch.utils import to_var
+from skorch.utils import params_for
 
 
 # pylint: disable=unused-argument
@@ -872,10 +873,7 @@ class NeuralNet(object):
         return iterator(dataset, **kwargs)
 
     def _get_params_for(self, prefix):
-        if not prefix.endswith('__'):
-            prefix += '__'
-        return {key[len(prefix):]: val for key, val in self.__dict__.items()
-                if key.startswith(prefix)}
+        return params_for(prefix, self.__dict__)
 
     def _get_param_names(self):
         return self.__dict__.keys()

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -35,3 +35,19 @@ class TestDuplicateItems:
     ])
     def test_duplicates(self, duplicate_items, collections, expected):
         assert duplicate_items(*collections) == expected
+
+
+class TestParamsFor:
+    @pytest.fixture
+    def params_for(self):
+        from skorch.utils import params_for
+        return params_for
+
+    @pytest.mark.parametrize('prefix, kwargs, expected', [
+        ('p1', {'p1__a': 1, 'p1__b': 2}, {'a': 1, 'b': 2}),
+        ('p2', {'p1__a': 1, 'p1__b': 2}, {}),
+        ('p1', {'p1__a': 1, 'p1__b': 2, 'p2__a': 3}, {'a': 1, 'b': 2}),
+        ('p2', {'p1__a': 1, 'p1__b': 2, 'p2__a': 3}, {'a': 3}),
+    ])
+    def test_params_for(self, params_for, prefix, kwargs, expected):
+        assert params_for(prefix, kwargs) == expected

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -148,3 +148,21 @@ def duplicate_items(*collections):
         else:
             seen.add(item)
     return duplicates
+
+
+def params_for(prefix, kwargs):
+    """Extract parameters that belong to a given sklearn module prefix from
+    ``kwargs``. This is useful to obtain parameters that belong to a
+    submodule.
+
+    Example usage
+    -------------
+    >>> kwargs = {'encoder__a': 3, 'encoder__b': 4, 'decoder__a': 5}
+    >>> params_for('encoder', kwargs)
+    {'a': 3, 'b': 4}
+
+    """
+    if not prefix.endswith('__'):
+        prefix += '__'
+    return {key[len(prefix):]: val for key, val in kwargs.items()
+            if key.startswith(prefix)}


### PR DESCRIPTION
Refactor `_get_params_for` to utility function. 

Makes it possible to use it in user code as well, e.g.
for assigning values in submodules, e.g.:
    
```python
def __init__(self, **kwargs):
     self.submod = Submod(**params_for('submod', kwargs)
```