### PR TITLE
Fix issue 112: EpochScoring flaky when y_test is None.

### DIFF
--- a/skorch/callbacks.py
+++ b/skorch/callbacks.py
@@ -272,7 +272,7 @@ class EpochScoring(ScoringBase):
       This is called on y before it is passed to scoring.
 
     """
-    # pylint: disable=unused-argument
+    # pylint: disable=unused-argument,arguments-differ
     def on_epoch_end(
             self,
             net,
@@ -291,7 +291,10 @@ class EpochScoring(ScoringBase):
         if X_test is None:
             return
 
-        y_test = self.target_extractor(y_test)
+        if y_test is not None:
+            # We allow y_test to be None but the scoring function has
+            # to be able to deal with it (i.e. called without y_test).
+            y_test = self.target_extractor(y_test)
         current_score = self._scoring(net, X_test, y_test)
         history.record(self.name_, current_score)
 

--- a/skorch/tests/test_callbacks.py
+++ b/skorch/tests/test_callbacks.py
@@ -272,6 +272,30 @@ class TestEpochScoring:
 
         assert extractor.call_count == 2
 
+    def test_without_target_data_works(
+            self, net_cls, module_cls, scoring_cls, data,
+    ):
+        def myscore(_, X, y=None):
+            assert y is None
+            return np.mean(X)
+
+        def mysplit(X, y):
+            # set y_valid to None
+            return X, X, y, None
+
+        X, y = data
+        net = net_cls(
+            module=module_cls,
+            callbacks=[scoring_cls(myscore)],
+            train_split=mysplit,
+            max_epochs=2,
+        )
+        net.fit(X, y)
+
+        expected = np.mean(X)
+        loss = net.history[:, 'myscore']
+        assert np.allclose(loss, expected)
+
 
 class TestBatchScoring:
     @pytest.fixture


### PR DESCRIPTION
The current solution is to not call `target_extractor`. That way, None is passed through, which will then lead sklearn to call the scoring function without y. Therefore, if the scoring function supports that, the user is fine.

The reason why `BatchScoring` does work here is because we currently replace non-existing y with a dummy tensor during batching. Of course, this is not ideal but not in the scope of this fix. It _may_ also solve itself with updates in pytorch.