### PR TITLE
Add 'auto' parameter to progress bar

### DIFF
--- a/skorch/tests/test_callbacks.py
+++ b/skorch/tests/test_callbacks.py
@@ -853,8 +853,8 @@ class TestProgressBar:
     @pytest.fixture(scope='module')
     def data(self):
         # have 10 examples so we can do a nice CV split
-        X = np.zeros((10, 1), dtype='float32')
-        y = np.zeros((10, 1), dtype='float32')
+        X = np.zeros((20, 1), dtype='float32')
+        y = np.zeros((20, 1), dtype='float32')
         return X, y
 
     @pytest.mark.parametrize('postfix', [
@@ -869,3 +869,18 @@ class TestProgressBar:
             progressbar_cls(postfix_keys=postfix),
         ])
         net.fit(*data)
+
+
+    @pytest.mark.parametrize('scheme', [
+        'count',
+        'auto',
+        2, # correct number of batches_per_epoch (20 // 10)
+        3, # offset by +1, should still work
+        1, # offset by -1, should still work
+    ])
+    def test_different_count_schemes(self, scheme, net_cls, progressbar_cls, data):
+        net = net_cls(callbacks=[
+            progressbar_cls(batches_per_epoch=scheme),
+        ])
+        net.fit(*data)
+

--- a/skorch/tests/test_callbacks.py
+++ b/skorch/tests/test_callbacks.py
@@ -870,17 +870,17 @@ class TestProgressBar:
         ])
         net.fit(*data)
 
-
     @pytest.mark.parametrize('scheme', [
         'count',
         'auto',
-        2, # correct number of batches_per_epoch (20 // 10)
-        3, # offset by +1, should still work
-        1, # offset by -1, should still work
+        None,
+        2,  # correct number of batches_per_epoch (20 // 10)
+        3,  # offset by +1, should still work
+        1,  # offset by -1, should still work
     ])
-    def test_different_count_schemes(self, scheme, net_cls, progressbar_cls, data):
+    def test_different_count_schemes(
+            self, scheme, net_cls, progressbar_cls, data):
         net = net_cls(callbacks=[
             progressbar_cls(batches_per_epoch=scheme),
         ])
         net.fit(*data)
-


### PR DESCRIPTION
Computes the batches per epoch automatically once training has started (on first epoch) but before the first computation is done. This is in contrast to the current 'count' method where we have to wait one epoch to know the proper number. While the latter is more stable, there are cases where we only train one epoch in total but still want a proper progress bar and don't necessarily know the number of batches per epoch beforehand (e.g. in a grid search scenario where we have the cv split but also a final run with the total number of training examples).
