### PR TITLE
Add a minimally useful repr to NeuralNet.

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1030,6 +1030,31 @@ class NeuralNet(object):
 
         self.module_.load_state_dict(model)
 
+    def __repr__(self):
+        params = self.get_params(deep=False)
+
+        to_include = ['module']
+        to_exclude = []
+        parts = [str(self.__class__) + ' (uninitialized) (']
+        if self.initialized_:
+            parts = [str(self.__class__) + ' (initialized) (']
+            to_include = ['module_']
+            to_exclude = ['module__']
+
+        for key, val in sorted(params.items()):
+            if not any(key.startswith(prefix) for prefix in to_include):
+                continue
+            if any(key.startswith(prefix) for prefix in to_exclude):
+                continue
+
+            val = str(val)
+            if '\n' in val:
+                val = '\n  '.join(val.split('\n'))
+            parts.append('  {}={},'.format(key, val))
+
+        parts.append(')')
+        return '\n'.join(parts)
+
 
 #######################
 # NeuralNetClassifier #

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -726,6 +726,55 @@ class TestNeuralNet:
                     "Dataset arguments ({'foo': 123}) is not allowed.")
         assert exc.value.args[0] == expected
 
+    def test_repr_uninitialized_works(self, net_cls, module_cls):
+        net = net_cls(
+            module_cls,
+            module__num_units=55,
+        )
+        result = net.__repr__()
+        expected = """<class 'skorch.net.NeuralNetClassifier'> (uninitialized) (
+  module=<class 'skorch.tests.test_net.MyClassifier'>,
+  module__num_units=55,
+)"""
+        assert result == expected
+
+    def test_repr_initialized_works(self, net_cls, module_cls):
+        net = net_cls(
+            module_cls,
+            module__num_units=42,
+        )
+        net.initialize()
+        result = net.__repr__()
+        expected = """<class 'skorch.net.NeuralNetClassifier'> (initialized) (
+  module_=MyClassifier (
+    (dense0): Linear (20 -> 42)
+    (dropout): Dropout (p = 0.5)
+    (dense1): Linear (42 -> 10)
+    (output): Linear (10 -> 2)
+  ),
+)"""
+        assert result == expected
+
+    def test_repr_fitted_works(self, net_cls, module_cls, data):
+        X, y = data
+        net = net_cls(
+            module_cls,
+            module__num_units=11,
+            module__nonlin=nn.PReLU(),
+        )
+        net.fit(X[:50], y[:50])
+        result = net.__repr__()
+        expected = """<class 'skorch.net.NeuralNetClassifier'> (initialized) (
+  module_=MyClassifier (
+    (dense0): Linear (20 -> 11)
+    (nonlin): PReLU (1)
+    (dropout): Dropout (p = 0.5)
+    (dense1): Linear (11 -> 10)
+    (output): Linear (10 -> 2)
+  ),
+)"""
+        assert result == expected
+
 
 class MyRegressor(nn.Module):
     """Simple regression module."""


### PR DESCRIPTION
My proposal in #67 looks a little over-blown. Here is a more minimal __repr__ that focuses on the module parameters only. With the following module:

```
class MyClassifier(nn.Module):
    def __init__(self, num_units=10, nonlin=F.relu):
        super(MyClassifier, self).__init__()

        self.dense0 = nn.Linear(20, num_units)
        self.nonlin = nonlin
        self.dropout = nn.Dropout(0.5)
        self.dense1 = nn.Linear(num_units, 10)
        self.output = nn.Linear(10, 2)

    def forward(self, X):
        X = self.nonlin(self.dense0(X))
        X = self.dropout(X)
        X = self.nonlin(self.dense1(X))
        X = F.softmax(self.output(X))
        return X

```
for an uninitialized net, the output looks like this:

```
<class 'skorch.net.NeuralNetClassifier'> (uninitialized) (
  module=<class 'skorch.tests.test_net.MyClassifier'>,
  module__num_units=42,
)
```

for the same, initialized net, it looks like this:

```
<class 'skorch.net.NeuralNetClassifier'> (initialized) (
  module_=MyClassifier (
    (dense0): Linear (20 -> 42)
    (dropout): Dropout (p = 0.5)
    (dense1): Linear (42 -> 10)
    (output): Linear (10 -> 2)
  ),
)
```