### PR TITLE
Clean up of inference methods and allow multioutput

### DIFF
--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -304,13 +304,11 @@ to a ``numpy`` array. Alternatively, consider using the
 ``forward_iter`` method to generate outputs from the ``module``, or
 directly call ``net.module_(X)``.
 
-The ``predict`` method tries to return the class labels by applying
-the argmax over the last axis of the result of
-``predict_proba``. Obviously, this only makes sense if
+In case of ``NeuralNetClassifier``, the ``predict`` method tries to
+return the class labels by applying the argmax over the last axis of
+the result of ``predict_proba``. Obviously, this only makes sense if
 ``predict_proba`` returns class probabilities. If this is not true,
-you should just use ``predict_proba``. (Since it deals with regression
-tasks, ``NeuralNetRegressor``\'s ``predict`` method just returns the
-result from ``predict_proba``, without applying argmax.)
+you should just use ``predict_proba``.
 
 saving and loading
 ^^^^^^^^^^^^^^^^^^

--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -295,7 +295,8 @@ predict(X) and predict_proba(X)
 These methods perform an inference step on the input data and return
 ``numpy array``\s. By default, ``predict_proba`` will return whatever
 it is that the ``module``\'s ``forward`` method returns, cast to a
-``numpy array``.
+``numpy array``. If ``forward`` returns multiple outputs as a tuple,
+only the first output is used, the rest is discarded.
 
 If casting the ``forward``\-output to ``numpy`` is impossible, you
 will get an error. In that case, you should consider returning a torch

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -723,14 +723,10 @@ class NeuralNet(object):
           The result from the forward step.
 
         """
-        y_infer = []
-        is_multioutput = None
-        for batch in self.forward_iter(X, training=training):
-            if is_multioutput is None:
-                is_multiouput = isinstance(batch, tuple)
-            y_infer.append(batch)
+        y_infer = list(self.forward_iter(X, training=training))
 
-        if is_multiouput:
+        is_multioutput = len(y_infer) > 0 and isinstance(y_infer[0], tuple)
+        if is_multioutput:
             return tuple(map(torch.cat, zip(*y_infer)))
         return torch.cat(y_infer)
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -685,8 +685,6 @@ class NeuralNet(object):
           Result from a forward call on an individual batch.
 
         """
-        self.module_.train(training)
-
         dataset = self.get_dataset(X)
         iterator = self.get_iterator(dataset, training=training)
         for Xi, _ in iterator:

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -660,7 +660,7 @@ class NeuralNet(object):
         return self
 
     def forward_iter(self, X, training=False):
-        """Yield forward results from batches derived from data.
+        """Yield outputs of forward calls on each batch of data.
 
         Parameters
         ----------
@@ -682,7 +682,7 @@ class NeuralNet(object):
         Yields
         ------
         yp : torch tensor
-          Result from a forward step on a batch.
+          Result from a forward call on an individual batch.
 
         """
         self.module_.train(training)

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -660,7 +660,7 @@ class NeuralNet(object):
         return self
 
     def forward_iter(self, X, training=False):
-        """Yield outputs of forward calls on each batch of data.
+        """Yield outputs of module forward calls on each batch of data.
 
         Parameters
         ----------

--- a/skorch/tests/conftest.py
+++ b/skorch/tests/conftest.py
@@ -56,6 +56,23 @@ def classifier_module():
 
 
 @pytest.fixture(scope='module')
+def multiouput_module():
+    """Return a simple classifier module class."""
+    class MultiOutput(nn.Module):
+        """Simple classification module."""
+        def __init__(self, input_units=20):
+            super(MultiOutput, self).__init__()
+            self.output = nn.Linear(input_units, 2)
+
+        # pylint: disable=arguments-differ
+        def forward(self, X):
+            X = F.softmax(self.output(X), dim=-1)
+            return X, X[:, 0], X[::2]
+
+    return MultiOutput
+
+
+@pytest.fixture(scope='module')
 def classifier_data():
     X, y = make_classification(1000, 20, n_informative=10, random_state=0)
     return X.astype(np.float32), y

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -151,6 +151,7 @@ class TestNeuralNet:
         y_forward = net_fit.forward(X)
 
         assert is_torch_data_type(y_forward)
+        # Expecting (number of samples, number of output units)
         assert y_forward.shape == (n, 2)
 
         y_proba = net_fit.predict_proba(X)
@@ -939,9 +940,12 @@ class TestNeuralNet:
         for arr in y_infer:
             assert is_torch_data_type(arr)
 
-        # 1st output is original, 2nd is only col 0, 3rd is only evey other row
+        # Expecting full output: (number of samples, number of output units)
         assert y_infer[0].shape == (n, 2)
+        # Expecting only column 0: (number of samples,)
         assert y_infer[1].shape == (n,)
+        # Expecting only every other row: (number of samples/2, number
+        # of output units)
         assert y_infer[2].shape == (n // 2, 2)
 
     def test_multioutput_predict(self, multiouput_net, data):
@@ -951,6 +955,8 @@ class TestNeuralNet:
         # does not raise
         y_pred = multiouput_net.predict(X)
 
+        # Expecting only 1 column containing predict class:
+        # (number of samples,)
         assert y_pred.shape == (n,)
         assert set(y_pred) == {0, 1}
 
@@ -961,7 +967,9 @@ class TestNeuralNet:
         # does not raise
         y_proba = multiouput_net.predict_proba(X)
 
+        # Expecting full output: (number of samples, number of output units)
         assert y_proba.shape == (n, 2)
+        # Probabilities, hence these limits
         assert y_proba.min() >= 0
         assert y_proba.max() <= 1
 

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -16,7 +16,8 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 
-from skorch.net import to_numpy
+from skorch.utils import to_numpy
+from skorch.utils import is_torch_data_type
 
 
 torch.manual_seed(0)
@@ -144,7 +145,18 @@ class TestNeuralNet:
         y_pred = net_fit.predict(X)
         assert accuracy_score(y, y_pred) > 0.7
 
-    def test_predict_proba(self, net_fit, data):
+    def test_forward(self, net_fit, data):
+        X = data[0]
+        n = len(X)
+        y_forward = net_fit.forward(X)
+
+        assert is_torch_data_type(y_forward)
+        assert y_forward.shape == (n, 2)
+
+        y_proba = net_fit.predict_proba(X)
+        assert np.allclose(to_numpy(y_forward), y_proba)
+
+    def test_predict_and_predict_proba(self, net_fit, data):
         X = data[0]
 
         y_proba = net_fit.predict_proba(X)


### PR DESCRIPTION
Addresses #141 and then some.

The following things were changed:

* Remove redundant `training` call in `forward_iter`
* There was no explicit test for `NeuralNet.foward` -- added it
* *breaking change*: `NeuralNet.predict` no longer performs argmax -- this makes only sense for a classifier, which `NeuralNet` isn't; as a consequence, `NeuralNetClassifier.predict` is now charged with taking the argmax.
* `NeuralNet.forward` can now deal with multiple outputs from `module_.forward`: If they are returned as a tuple, they are separated and `torch.cat` is called on each of them individually.
* `predict` and `predict_proba`  can now deal with multiple outputs from `module_.forward`: They discard all but the first output if outputs are tuples.
* Improve and adjust docstrings, documentation

Not changed:

* Allow to pull batches to CPU when calling `NeuralNet.foward`. I would like to think a bit more about how to handle the parameters before taking on this issue (e.g. `store_on='cpu'` vs `store_on_cpu=True`).