### PR TITLE
Explicitly cast y to 64 bit for 32 bit archs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ To see a more elaborate example, look `here
 
     X, y = make_classification(1000, 20, n_informative=10, random_state=0)
     X = X.astype(np.float32)
-
+    y = y.astype(np.int64)
 
     class MyModule(nn.Module):
         def __init__(self, num_units=10, nonlin=F.relu):

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -21,7 +21,7 @@ classification dataset using skorch\'s ``NeuralNetClassifier``:
 
     X, y = make_classification(1000, 20, n_informative=10, random_state=0)
     X = X.astype(np.float32)
-
+    y = y.astype(np.int64)
 
     class MyModule(nn.Module):
         def __init__(self, num_units=10, nonlin=F.relu):


### PR DESCRIPTION
Addresses #161. Some stacks with 32 bit components (e.g. numpy)
may default to 32 bit integers for `y` in `make_classification`
but torch expects 64 bit values.