### PR TITLE
Resolve #145 by implementing location parameter

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -669,6 +669,8 @@ class NeuralNet(object):
 
     def forward_iter(self, X, training=False, location='cpu'):
         """Yield outputs of module forward calls on each batch of data.
+        The storage location of the yielded tensors is determined
+        by the ``location`` parameter.
 
         Parameters
         ----------
@@ -715,10 +717,11 @@ class NeuralNet(object):
         """Gather and concatenate the output from forward call with
         input data.
 
-        The outputs from ``self.module_.forward`` are gathered and
-        then concatenated using ``torch.cat``. If multiple outputs are
-        returned y ``self.module_.forward``, each one of them must be
-        able to be concatenated this way.
+        The outputs from ``self.module_.forward`` are gathered on the
+        compute device specified by ``location`` and then concatenated
+        using ``torch.cat``. If multiple outputs are returned by
+        ``self.module_.forward``, each one of them must be able to be
+        concatenated this way.
 
         Parameters
         ----------
@@ -736,6 +739,13 @@ class NeuralNet(object):
 
         training : bool (default=False)
           Whether to set the module to train mode or not.
+
+        location : string (default='cpu')
+          The location to store each inference result on.
+          This defaults to CPU memory since there is genereally
+          more memory available there. For performance reasons
+          this might be changed to a specific CUDA device,
+          e.g. 'cuda:0'.
 
         Returns
         -------

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -157,6 +157,25 @@ class TestNeuralNet:
         y_proba = net_fit.predict_proba(X)
         assert np.allclose(to_numpy(y_forward), y_proba)
 
+    def test_forward_location_cpu(self, net_fit, data):
+        X = data[0]
+
+        # CPU by default
+        y_forward = net_fit.forward(X)
+        assert isinstance(X, np.ndarray)
+        assert not y_forward.is_cuda
+
+        y_forward = net_fit.forward(X, location='cpu')
+        assert isinstance(X, np.ndarray)
+        assert not y_forward.is_cuda
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda device")
+    def test_forward_location_gpu(self, net_fit, data):
+        X = data[0]
+        y_forward = net_fit.forward(X, location='cuda:0')
+        assert isinstance(X, np.ndarray)
+        assert y_forward.is_cuda
+
     def test_predict_and_predict_proba(self, net_fit, data):
         X = data[0]
 

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -967,6 +967,16 @@ class TestNeuralNet:
         # of output units)
         assert y_infer[2].shape == (n // 2, 2)
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda device")
+    def test_multioutput_forward_location_gpu(self, multiouput_net, data):
+        X = data[0]
+        y_infer = multiouput_net.forward(X, location='cuda:0')
+
+        assert isinstance(y_infer, tuple)
+        assert len(y_infer) == 3
+        for arr in y_infer:
+            assert arr.is_cuda
+
     def test_multioutput_predict(self, multiouput_net, data):
         X = data[0]
         n = len(X)


### PR DESCRIPTION
You can now pass a `location` paramter to `forward` which
indicates on which device to store the intermediate results.