### PR TITLE
set_params with unknown key on callback should raise

### DIFF
--- a/skorch/callbacks/base.py
+++ b/skorch/callbacks/base.py
@@ -66,6 +66,5 @@ class Callback:
         return BaseEstimator.get_params(self, deep=deep)
 
     def set_params(self, **params):
-        for key, val in params.items():
-            setattr(self, key, val)
+        BaseEstimator.set_params(self, **params)
         return self

--- a/skorch/tests/test_callbacks.py
+++ b/skorch/tests/test_callbacks.py
@@ -46,6 +46,20 @@ class TestAllCallbacks:
             method = getattr(callback, method_name)
             assert "kwargs" in inspect.signature(method).parameters
 
+    @pytest.fixture
+    def base_cls(self):
+        from skorch.callbacks import Callback
+        return Callback
+
+    def test_set_params_with_unknown_key_raises(self, base_cls):
+        with pytest.raises(ValueError) as exc:
+            base_cls().set_params(foo=123)
+
+        msg = ("Invalid parameter foo for estimator Callback. "
+               "Check the list of available parameters with "
+               "`estimator.get_params().keys()`.")
+        assert exc.value.args[0] == msg
+
 
 class TestPrintLog:
     @pytest.fixture

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -378,6 +378,15 @@ class TestNeuralNet:
         assert net.module_.nonlin is F.tanh
         assert np.isclose(net.lr, 0.2)
 
+    def test_set_params_with_unknown_key_raises(self, net):
+        with pytest.raises(ValueError) as exc:
+            net.set_params(foo=123)
+
+        msg = ("Invalid parameter foo for estimator NeuralNetClassifier. "
+               "Check the list of available parameters with "
+               "`estimator.get_params().keys()`.")
+        assert exc.value.args[0] == msg
+
     def test_changing_model_reinitializes_optimizer(self, net, data):
         # The idea is that we change the model using `set_params` to
         # add parameters. Since the optimizer depends on the model


### PR DESCRIPTION
Previously, this parameter was just set as an attribute. The correct
behavior is to raise a ValueError, as sklearn would.

Addresses #175 