### PR TITLE
Classifier only applies log if nll loss

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -212,7 +212,7 @@ In general, this should work (assuming CUDA 9):
     # using conda:
     conda install pytorch cuda90 -c pytorch
     # using pip
-    pip install http://download.pytorch.org/whl/cu90/torch-0.3.0.post4-cp36-cp36m-linux_x86_64.whl
+    pip install http://download.pytorch.org/whl/cu90/torch-0.4.0-cp36-cp36m-linux_x86_64.whl
 
 =============
 Communication

--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -92,18 +92,26 @@ would look like this:
 It is, however, also possible to pass an instantiated module, e.g. a
 ``torch.nn.Sequential`` instance.
 
-Note that skorch does not automatically apply any nonlinearities
-to the outputs. That means that if you have a classification task, you
-should make sure that the final output nonlinearity is a
-softmax. Otherwise, when you call ``predict_proba``, you won't get
-actual probabilities.
+Note that skorch does not automatically apply any nonlinearities to
+the outputs (except internally when determining the
+``torch.nn.NLLLoss``, see below). That means that if you have a
+classification task, you should make sure that the final output
+nonlinearity is a softmax. Otherwise, when you call ``predict_proba``,
+you won't get actual probabilities.
 
 criterion
 ^^^^^^^^^
 
-This should be a PyTorch (-compatible) criterion. When you use the
-``NeuralNetClassifier``, the criterion is set to ``torch.nn.NLLLoss``
-by default, for ``NeuralNetRegressor``, it is ``torch.nn.MSELoss``.
+This should be a PyTorch (-compatible) criterion.
+
+When you use the ``NeuralNetClassifier``, the criterion is set to
+``torch.nn.NLLLoss`` by default. Furthermore, if you don't change it
+loss to another criterion, ``NeuralNetClassifier`` assumes that the
+module returns probabilities and will automatically apply a logarithm
+on them (which is what ``torch.nn.NLLLoss`` expects).
+
+For ``NeuralNetRegressor``, the default criterion is
+``torch.nn.MSELoss``.
 
 After initializing the ``NeuralNet``, the initialized criterion will
 stored in the ``criterion_`` attribute.

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1428,8 +1428,9 @@ class NeuralNetClassifier(NeuralNet):
 
     # pylint: disable=arguments-differ
     def get_loss(self, y_pred, y_true, *args, **kwargs):
-        y_pred_log = torch.log(y_pred)
-        return super().get_loss(y_pred_log, y_true, *args, **kwargs)
+        if isinstance(self.criterion_, torch.nn.NLLLoss):
+            y_pred = torch.log(y_pred)
+        return super().get_loss(y_pred, y_true, *args, **kwargs)
 
     # pylint: disable=signature-differs
     def fit(self, X, y, **fit_params):


### PR DESCRIPTION
This should hopefully avoid some confusion when another loss than `NLLLoss` is used. However, there will still be an error when using `NLLLoss` and having your module return log-probas.

Partially addresses #197\, #137\, #136