### PR TITLE
MAINT: enforce torch version

### DIFF
--- a/skorch/__init__.py
+++ b/skorch/__init__.py
@@ -7,15 +7,15 @@ MIN_TORCH_VERSION = '0.4.0'
 
 try:
     import torch
-except:  # pylint: disable=bare-except
-    raise Exception('skorch depends on PyTorch. Visit https://pytorch.org/ '
-                    'for install instructions')
+except ModuleNotFoundError:
+    raise ModuleNotFoundError("No module named 'torch', and skorch depends on PyTorch (aka 'torch'). "
+                              'Visit https://pytorch.org/ for installation instructions')
 
 torch_version = pkg_resources.get_distribution('torch').version
 if parse_version(torch_version) < parse_version(MIN_TORCH_VERSION):
-    msg = ('skorch depends a newer version of PyTorch (at least {req}, not '
-           '{installed}). Visit https://pytorch.org for install details')
-    raise Exception(msg.format(req=MIN_TORCH_VERSION, installed=torch_version))
+    msg = ('skorch depends on a newer version of PyTorch (at least {req}, not '
+           '{installed}). Visit https://pytorch.org for installation details')
+    raise ImportWarning(msg.format(req=MIN_TORCH_VERSION, installed=torch_version))
 
 
 from .history import History

--- a/skorch/__init__.py
+++ b/skorch/__init__.py
@@ -1,6 +1,22 @@
 """skorch base imports"""
 
 import pkg_resources
+from pkg_resources import parse_version
+
+MIN_TORCH_VERSION = '0.4.0'
+
+try:
+    import torch
+except:  # pylint: disable=bare-except
+    raise Exception('skorch depends on PyTorch. Visit https://pytorch.org/ '
+                    'for install instructions')
+
+torch_version = pkg_resources.get_distribution('torch').version
+if parse_version(torch_version) < parse_version(MIN_TORCH_VERSION):
+    msg = ('skorch depends a newer version of PyTorch (at least {req}, not '
+           '{installed}). Visit https://pytorch.org for install details')
+    raise Exception(msg.format(req=MIN_TORCH_VERSION, installed=torch_version))
+
 
 from .history import History
 from .net import NeuralNet


### PR DESCRIPTION
Closes #202 

This does require maintaining the minimum required torch version. I coded this as a `MIN_TORCH_VERSION` in `skorch/__init__.py`. Will that work?

I tested this with torch 0.3.1 and it threw the error. With torch 0.4.0 it didn't.