### PR TITLE
Fix a bug with caching that sometimes prevented infer to be reset.

### DIFF
--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -27,11 +27,14 @@ def cache_net_infer(net, use_caching, y_preds):
         return
     y_preds = iter(y_preds)
     net.infer = lambda *a, **kw: next(y_preds)
-    yield net
-    # By setting net.infer we define an attribute `infer`
-    # that precedes the bound method `infer`. By deleting
-    # the entry from the attribute dict we undo this.
-    del net.__dict__['infer']
+
+    try:
+        yield net
+    finally:
+        # By setting net.infer we define an attribute `infer`
+        # that precedes the bound method `infer`. By deleting
+        # the entry from the attribute dict we undo this.
+        del net.__dict__['infer']
 
 
 class ScoringBase(Callback):

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -679,6 +679,6 @@ class TestBatchScoring:
 
         y_pred = net.predict(X)
         # We test that we predict as many outputs as we put in. With
-        # the bug, the cache would be partially exhausted and we would
-        # get back less.
+        # the bug, the cache would be exhausted early because of the
+        # train split, and we would get back less.
         assert len(y_pred) == len(X)


### PR DESCRIPTION
Namely, when during the training process the training is finished
irregularly (e.g. through KeyboardInterrupt) when the net is still
cached, the caching would not be reset.