### PR TITLE
lr scheduler can now monitor other fields

### DIFF
--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -29,9 +29,10 @@ class LRScheduler(Callback):
       Learning rate policy name or scheduler to be used.
 
     monitor : str or callable (default=None)
-      Value of the history to monitor or callback that determines whether
-      this epoch should to a checkpoint. The callback takes the network
-      instance as parameter.
+      Value of the history to monitor or function/callable that. In
+      the latter case, the callable receives the net instance as
+      argument and is expected to return the score (float) used to
+      determine the learning rate adjustment.
 
     kwargs
       Additional arguments passed to the lr scheduler.

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -29,7 +29,7 @@ class LRScheduler(Callback):
       Learning rate policy name or scheduler to be used.
 
     monitor : str or callable (default=None)
-      Value of the history to monitor or function/callable that. In
+      Value of the history to monitor or function/callable. In
       the latter case, the callable receives the net instance as
       argument and is expected to return the score (float) used to
       determine the learning rate adjustment.

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -1,9 +1,9 @@
 """Contains learning rate scheduler callbacks"""
 
 import sys
-import numpy as np
 
 # pylint: disable=unused-import
+import numpy as np
 from torch.optim.lr_scheduler import _LRScheduler
 from torch.optim.lr_scheduler import CosineAnnealingLR
 from torch.optim.lr_scheduler import ExponentialLR
@@ -18,12 +18,6 @@ from skorch.callbacks import Callback
 __all__ = ['LRScheduler', 'WarmRestartLR', 'CyclicLR']
 
 
-def previous_epoch_train_loss_score(net):
-    losses = net.history[-2, 'batches', :, 'train_loss']
-    batch_sizes = net.history[-2, 'batches', :, 'train_batch_size']
-    return np.average(losses, weights=batch_sizes)
-
-
 class LRScheduler(Callback):
     """Callback that sets the learning rate of each
     parameter group according to some policy.
@@ -34,13 +28,19 @@ class LRScheduler(Callback):
     policy : str or _LRScheduler class (default='WarmRestartLR')
       Learning rate policy name or scheduler to be used.
 
+    monitor : str or callable (default=None)
+      Value of the history to monitor or callback that determines whether
+      this epoch should to a checkpoint. The callback takes the network
+      instance as parameter.
+
     kwargs
       Additional arguments passed to the lr scheduler.
 
     """
 
-    def __init__(self, policy='WarmRestartLR', **kwargs):
+    def __init__(self, policy='WarmRestartLR', monitor='train_loss', **kwargs):
         self.policy = policy
+        self.monitor = monitor
         self.kwargs = kwargs
 
     def initialize(self):
@@ -57,10 +57,13 @@ class LRScheduler(Callback):
         )
 
     def on_epoch_begin(self, net, **kwargs):
-        epoch = len(net.history)-1
+        epoch = len(net.history) - 1
         if isinstance(self.lr_scheduler_, ReduceLROnPlateau):
-            metrics = previous_epoch_train_loss_score(net) if epoch else np.inf
-            self.lr_scheduler_.step(metrics, epoch)
+            if callable(self.monitor):
+                score = self.monitor(net)
+            else:
+                score = net.history[-2, self.monitor] if epoch else np.inf
+            self.lr_scheduler_.step(score, epoch)
         else:
             self.lr_scheduler_.step(epoch)
 
@@ -94,6 +97,7 @@ class LRScheduler(Callback):
         current_batch_idx = len(net.history[-1, 'batches'])
         batch_cnt = len(net.history[-2, 'batches']) if epoch >= 1 else 0
         return epoch * batch_cnt + current_batch_idx
+
 
 class WarmRestartLR(_LRScheduler):
     """Stochastic Gradient Descent with Warm Restarts (SGDR) scheduler.
@@ -175,6 +179,7 @@ class WarmRestartLR(_LRScheduler):
             epoch_idx
         )
         return current_lrs.tolist()
+
 
 class CyclicLR(object):
     """Sets the learning rate of each parameter group according to

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -46,9 +46,9 @@ class Checkpoint(Callback):
       >>> cb = Checkpoint(target="target_{last_epoch[epoch]}.pt")
 
     monitor : str, function, None
-      Value of the history to monitor or callback that determines whether
-      this epoch should to a checkpoint. The callback takes the network
-      instance as parameter.
+      Value of the history to monitor or callback that determines
+      whether this epoch should lead to a checkpoint. The callback
+      takes the network instance as parameter.
 
       In case ``monitor`` is set to ``None``, the callback will save
       the network at every epoch.

--- a/skorch/tests/test_lr_scheduler.py
+++ b/skorch/tests/test_lr_scheduler.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from torch.optim import SGD
 from torch.optim.lr_scheduler import StepLR
+from torch.optim.lr_scheduler import CosineAnnealingLR
 from torch.optim.lr_scheduler import LambdaLR
 from torch.optim.lr_scheduler import MultiStepLR
 from torch.optim.lr_scheduler import ExponentialLR
@@ -25,6 +26,7 @@ class TestLRCallbacks:
         ('ReduceLROnPlateau', ReduceLROnPlateau, {}),
         ('WarmRestartLR', WarmRestartLR, {}),
         ('CyclicLR', CyclicLR, {}),
+        ('CosineAnnealingLR', CosineAnnealingLR, {'T_max': 5, 'eta_min': 1e-3}),
         (WarmRestartLR, WarmRestartLR, {}),
     ])
     def test_lr_callback_init_policies(
@@ -54,6 +56,7 @@ class TestLRCallbacks:
         ('ExponentialLR', {'gamma': 0.1}),
         ('ReduceLROnPlateau', {}),
         ('WarmRestartLR', {}),
+        ('CosineAnnealingLR', {'T_max': 3}),
     ])
     def test_lr_callback_steps_correctly(
             self,

--- a/skorch/tests/test_lr_scheduler.py
+++ b/skorch/tests/test_lr_scheduler.py
@@ -106,6 +106,7 @@ class TestWarmRestartLR():
     def assert_lr_correct(
             self, optimizer, targets, epochs, min_lr, max_lr, base_period,
             period_mult):
+        """Test that learning rate was set correctly."""
         targets = [targets] if len(optimizer.param_groups) == 1 else targets
         scheduler = WarmRestartLR(
             optimizer, min_lr, max_lr, base_period, period_mult

--- a/skorch/tests/test_lr_scheduler.py
+++ b/skorch/tests/test_lr_scheduler.py
@@ -141,8 +141,8 @@ class TestReduceLROnPlateau:
         np.isclose(score, net.history[-2, monitor])
 
     def test_reduce_lr_monitor_with_callable(self):
-        # step should be called with the 2nd to last value from that
-        # history entry
+        # step should always be called with the return value from the
+        # callable, 55
         _, mock_step = self.get_net_with_mock(monitor=lambda x: 55)
         score = mock_step.call_args_list[0][0][0]
         assert score == 55

--- a/skorch/tests/test_lr_scheduler.py
+++ b/skorch/tests/test_lr_scheduler.py
@@ -1,19 +1,19 @@
 """Tests for lr_scheduler.py"""
 
-import pytest
-import numpy as np
+from unittest.mock import Mock
 
+import numpy as np
+import pytest
 from torch.optim import SGD
-from torch.optim.lr_scheduler import StepLR
 from torch.optim.lr_scheduler import CosineAnnealingLR
+from torch.optim.lr_scheduler import ExponentialLR
 from torch.optim.lr_scheduler import LambdaLR
 from torch.optim.lr_scheduler import MultiStepLR
-from torch.optim.lr_scheduler import ExponentialLR
 from torch.optim.lr_scheduler import ReduceLROnPlateau
+from torch.optim.lr_scheduler import StepLR
 
 from skorch.net import NeuralNetClassifier
-from skorch.callbacks.lr_scheduler import (
-    WarmRestartLR, LRScheduler, CyclicLR)
+from skorch.callbacks.lr_scheduler import WarmRestartLR, LRScheduler, CyclicLR
 
 
 class TestLRCallbacks:
@@ -100,6 +100,52 @@ class TestLRCallbacks:
         expected = (num_examples // batch_size) * max_epochs
         # pylint: disable=protected-access
         assert lr_policy.lr_scheduler_.last_batch_idx == expected
+
+
+class TestReduceLROnPlateau:
+    def get_net_with_mock(self, monitor='train_loss'):
+        """Returns a net with a mocked lr policy that allows to check what
+        it's step method was called with.
+
+        """
+        from .conftest import classifier_data, classifier_module
+
+        X, y = classifier_data()
+        net = NeuralNetClassifier(
+            classifier_module(),
+            callbacks=[
+                ('scheduler', LRScheduler(ReduceLROnPlateau, monitor=monitor)),
+            ],
+            max_epochs=1,
+        ).fit(X, y)
+
+        # mock the policy
+        policy = dict(net.callbacks_)['scheduler'].lr_scheduler_
+        mock_step = Mock(side_effect=policy.step)
+        policy.step = mock_step
+
+        # make sure that mocked policy is set
+        scheduler = dict(net.callbacks_)['scheduler']
+        # pylint: disable=protected-access
+        scheduler._get_scheduler = lambda *args, **kwargs: policy
+
+        net.partial_fit(X, y)
+        return net, mock_step
+
+    @pytest.mark.parametrize('monitor', ['train_loss', 'valid_loss', 'epoch'])
+    def test_reduce_lr_monitor_with_string(self, monitor):
+        # step should be called with the 2nd to last value from that
+        # history entry
+        net, mock_step = self.get_net_with_mock(monitor=monitor)
+        score = mock_step.call_args_list[0][0][0]
+        np.isclose(score, net.history[-2, monitor])
+
+    def test_reduce_lr_monitor_with_callable(self):
+        # step should be called with the 2nd to last value from that
+        # history entry
+        _, mock_step = self.get_net_with_mock(monitor=lambda x: 55)
+        score = mock_step.call_args_list[0][0][0]
+        assert score == 55
 
 
 class TestWarmRestartLR():


### PR DESCRIPTION
`LRScheduler` now allows you to monitor vars other than train_loss.

The class now takes a 'monitor' argument (like `Checkpoint`). If this is
a string, this value from the history is passed to step. If it is a
callable, the value returned by calling this callable with net is is
passed to step.

Moreover, some minor clean ups.