### PR TITLE
Default train/valid loss callbacks should have no-op target extractor

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -24,9 +24,10 @@ from skorch.history import History
 from skorch.utils import duplicate_items
 from skorch.utils import get_dim
 from skorch.utils import is_dataset
+from skorch.utils import noop
+from skorch.utils import params_for
 from skorch.utils import to_numpy
 from skorch.utils import to_tensor
-from skorch.utils import params_for
 
 
 # pylint: disable=unused-argument
@@ -256,10 +257,12 @@ class NeuralNet(object):
                 train_loss_score,
                 name='train_loss',
                 on_train=True,
+                target_extractor=noop,
             )),
             ('valid_loss', BatchScoring(
                 valid_loss_score,
                 name='valid_loss',
+                target_extractor=noop,
             )),
             ('print_log', PrintLog()),
         ]
@@ -1401,10 +1404,12 @@ class NeuralNetClassifier(NeuralNet):
                 train_loss_score,
                 name='train_loss',
                 on_train=True,
+                target_extractor=noop,
             )),
             ('valid_loss', BatchScoring(
                 valid_loss_score,
                 name='valid_loss',
+                target_extractor=noop,
             )),
             ('valid_acc', EpochScoring(
                 'accuracy',

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -264,3 +264,13 @@ def is_skorch_dataset(ds):
     if isinstance(ds, Subset):
         return is_skorch_dataset(ds.dataset)
     return isinstance(ds, Dataset)
+
+
+# pylint: disable=unused-argument
+def noop(*args, **kwargs):
+    """No-op function that does nothing and returns ``None``.
+
+    This is useful for defining scoring callbacks that do not need a
+    target extractor.
+    """
+    pass


### PR DESCRIPTION
Both of these callbacks retrieve already computed losses from the history, thus they do not need target and they do not need to process it in any way.

I care about this case for the following reason. I am implementing a multi-task network which has several outputs. The target values are actually dictionaries with the ground truth output for these several tasks. Naturally, I implemented a custom loss function which takes care of this. Now I expect the default scoring to be able to report training loss (because it was computed already). Right now it is not possible, because the default `target_extractor` is `to_numpy()`, which does not work with dictionaries (which my `y`s are).

In future the lambda can be replaced with Python [`noop()`](https://www.python.org/dev/peps/pep-0559/) built-in.