### PR TITLE
ENH: Adds history loading and saving

### DIFF
--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -419,9 +419,10 @@ initialize a :class:`.NeuralNet` to load the parameters again:
     new_net.initialize()  # This is important!
     new_net.load_params('some-file.pkl')
 
-In addition to saving the model, the history can persist by
-calling :func:`~skorch.net.NeuralNet.save_history` and
-:func:`~skorch.net.NeuralNet.load_history` methods on
+In addition to saving the model parameters, the history
+can be saved and loaded by calling the
+:func:`~skorch.net.NeuralNet.save_history`
+and :func:`~skorch.net.NeuralNet.load_history` methods on
 :class:`.NeuralNet`. This feature can be used to
 continue training:
 
@@ -529,5 +530,5 @@ total loss:
             loss += self.lambda1 * sum([w.abs().sum() for w in self.module_.parameters()])
             return loss
 
-.. note:: This example also reguralizes the biases, which you typically
+.. note:: This example also regularizes the biases, which you typically
     don't need to do.

--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -419,6 +419,37 @@ initialize a :class:`.NeuralNet` to load the parameters again:
     new_net.initialize()  # This is important!
     new_net.load_params('some-file.pkl')
 
+In addition to saving the model, the history can persist by
+calling :func:`~skorch.net.NeuralNet.save_history` and
+:func:`~skorch.net.NeuralNet.load_history` methods on
+:class:`.NeuralNet`. This feature can be used to
+continue training:
+
+.. code:: python
+
+    net = NeuralNet(
+        module=MyModule
+        criterion=torch.nn.NLLLoss,
+    )
+
+    net.fit(X, y, epochs=2) # Train for 2 epochs
+
+    net.save_params('some-file.pkl')
+    net.save_history('history.json')
+
+    new_net = NeuralNet(
+        module=MyModule
+        criterion=torch.nn.NLLLoss,
+    )
+    new_net.initialize() # This is important!
+    new_net.load_params('some-file.pkl')
+    new_net.save_history('history.json')
+
+    new_net.fit(X, y, epochs=2) # Train for another 2 epochs
+
+.. note:: In order to use this feature, the history
+    must only contain JSON encodable Python data structures.
+    Numpy and PyTorch types should not be in the history.
 
 Special arguments
 -----------------
@@ -498,5 +529,5 @@ total loss:
             loss += self.lambda1 * sum([w.abs().sum() for w in self.module_.parameters()])
             return loss
 
-*Note*: This example also reguralizes the biases, which you typically
- don't need to do.
+.. note:: This example also reguralizes the biases, which you typically
+    don't need to do.

--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -443,7 +443,7 @@ continue training:
     )
     new_net.initialize() # This is important!
     new_net.load_params('some-file.pkl')
-    new_net.save_history('history.json')
+    new_net.load_history('history.json')
 
     new_net.fit(X, y, epochs=2) # Train for another 2 epochs
 

--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -199,7 +199,7 @@ class BatchScoring(ScoringBase):
 
         history.record(self.name_, score_avg)
         if is_best is not None:
-            history.record(self.name_ + '_best', is_best)
+            history.record(self.name_ + '_best', bool(is_best))
 
 
 class EpochScoring(ScoringBase):
@@ -344,7 +344,7 @@ class EpochScoring(ScoringBase):
             if is_best is None:
                 return
 
-            cached_net.history.record(self.name_ + '_best', is_best)
+            cached_net.history.record(self.name_ + '_best', bool(is_best))
             if is_best:
                 self.best_score_ = current_score
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -26,10 +26,10 @@ from skorch.utils import duplicate_items
 from skorch.utils import get_dim
 from skorch.utils import is_dataset
 from skorch.utils import noop
+from skorch.utils import open_file_like
 from skorch.utils import params_for
 from skorch.utils import to_numpy
 from skorch.utils import to_tensor
-from skorch.utils import _with_file_like
 
 
 # pylint: disable=unused-argument
@@ -1336,33 +1336,31 @@ class NeuralNet(object):
 
         Examples
         --------
+
         >>> before = NeuralNetClassifier(mymodule)
-        >>> before.save_history('path/to/file.json')
         >>> before.fit(X, y)
+        >>> before.save_params('path/to/params')
+        >>> before.save_history('path/to/history.json')
         >>> after = NeuralNetClassifier(mymodule).initialize()
-        >>> after.load_history('path/to/file.json')
+        >>> after.load_params('path/to/params')
+        >>> after.load_history('path/to/history.json')
+        >>> # Continue training
+        >>> after.fit(X, y)
 
         """
-        with _with_file_like(f, 'w') as fp:
+        with open_file_like(f, 'w') as fp:
             json.dump(self.history.to_list(), fp)
 
     def load_history(self, f):
-        """Load the history of a ``NeuralNet`` from a json file.
+        """Load the history of a ``NeuralNet`` from a json file. See
+        ``save_history`` for an example.
 
         Parameters
         ----------
         f : file-like object or str
 
-        Examples
-        --------
-        >>> before = NeuralNetClassifier(mymodule)
-        >>> before.save_history('path/to/file.json')
-        >>> before.fit(X, y)
-        >>> after = NeuralNetClassifier(mymodule).initialize()
-        >>> after.load_history('path/to/file.json')
-
         """
-        with _with_file_like(f, 'r') as fp:
+        with open_file_like(f, 'r') as fp:
             self.history = History(json.load(fp))
 
     def __repr__(self):

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -2,6 +2,7 @@
 
 import fnmatch
 from itertools import chain
+import json
 import re
 import tempfile
 import warnings
@@ -28,6 +29,7 @@ from skorch.utils import noop
 from skorch.utils import params_for
 from skorch.utils import to_numpy
 from skorch.utils import to_tensor
+from skorch.utils import _with_file_like
 
 
 # pylint: disable=unused-argument
@@ -1324,6 +1326,44 @@ class NeuralNet(object):
             model = torch.load(f)
 
         self.module_.load_state_dict(model)
+
+    def save_history(self, f):
+        """Saves the history of ``NeuralNet`` as a json file.
+
+        Parameters
+        ----------
+        f : file-like object or str
+
+        Examples
+        --------
+        >>> before = NeuralNetClassifier(mymodule)
+        >>> before.save_history('path/to/file.json')
+        >>> before.fit(X, y)
+        >>> after = NeuralNetClassifier(mymodule).initialize()
+        >>> after.load_history('path/to/file.json')
+
+        """
+        with _with_file_like(f, 'w') as fp:
+            json.dump(self.history.to_list(), fp)
+
+    def load_history(self, f):
+        """Load the history of a ``NeuralNet`` from a json file.
+
+        Parameters
+        ----------
+        f : file-like object or str
+
+        Examples
+        --------
+        >>> before = NeuralNetClassifier(mymodule)
+        >>> before.save_history('path/to/file.json')
+        >>> before.fit(X, y)
+        >>> after = NeuralNetClassifier(mymodule).initialize()
+        >>> after.load_history('path/to/file.json')
+
+        """
+        with _with_file_like(f, 'r') as fp:
+            self.history = History(json.load(fp))
 
     def __repr__(self):
         params = self.get_params(deep=False)

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1328,7 +1328,10 @@ class NeuralNet(object):
         self.module_.load_state_dict(model)
 
     def save_history(self, f):
-        """Saves the history of ``NeuralNet`` as a json file.
+        """Saves the history of ``NeuralNet`` as a json file. In order
+        to use this feature, the history must only contain JSON encodable
+        Python data structures. Numpy and PyTorch types should not
+        be in the history.
 
         Parameters
         ----------
@@ -1338,14 +1341,13 @@ class NeuralNet(object):
         --------
 
         >>> before = NeuralNetClassifier(mymodule)
-        >>> before.fit(X, y)
+        >>> before.fit(X, y, epoch=2) # Train for 2 epochs
         >>> before.save_params('path/to/params')
         >>> before.save_history('path/to/history.json')
         >>> after = NeuralNetClassifier(mymodule).initialize()
         >>> after.load_params('path/to/params')
         >>> after.load_history('path/to/history.json')
-        >>> # Continue training
-        >>> after.fit(X, y)
+        >>> after.fit(X, y, epoch=2) # Train for another 2 epochs
 
         """
         with open_file_like(f, 'w') as fp:
@@ -1353,7 +1355,7 @@ class NeuralNet(object):
 
     def load_history(self, f):
         """Load the history of a ``NeuralNet`` from a json file. See
-        ``save_history`` for an example.
+        ``save_history`` for examples.
 
         Parameters
         ----------

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -360,33 +360,22 @@ class TestNeuralNet:
 
         assert net.history == history_before
 
-    def test_save_load_history_file_str(
-            self, net_cls, module_cls, net_fit, data, tmpdir):
-        net = net_cls(module_cls).initialize()
-        X, y = data
-
-        history_before = net_fit.history
-
-        p = tmpdir.mkdir('skorch').join('history.json')
-        net_fit.save_history(str(p))
-        del net_fit
-        net.load_history(str(p))
-
-        assert net.history == history_before
-
+    @pytest.mark.parametrize('converter', [str, Path])
     def test_save_load_history_file_path(
-            self, net_cls, module_cls, net_fit, data, tmpdir):
+            self, net_cls, module_cls, net_fit, data, tmpdir, converter):
+        # Test loading/saving with different kinds of path representations.
         net = net_cls(module_cls).initialize()
         X, y = data
 
         history_before = net_fit.history
 
         p = tmpdir.mkdir('skorch').join('history.json')
-        net_fit.save_history(Path(p))
+        net_fit.save_history(converter(p))
         del net_fit
-        net.load_history(Path(p))
+        net.load_history(converter(p))
 
         assert net.history == history_before
+
     @pytest.mark.parametrize('method, call_count', [
         ('on_train_begin', 1),
         ('on_train_end', 1),

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -4,6 +4,7 @@ from functools import partial
 import pickle
 from unittest.mock import Mock
 from unittest.mock import patch
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -343,6 +344,49 @@ class TestNeuralNet:
             'Model configured to use CUDA but no CUDA '
             'devices available. Loading on CPU instead.')
 
+    def test_save_load_history_file_obj(
+            self, net_cls, module_cls, net_fit, data, tmpdir):
+        net = net_cls(module_cls).initialize()
+        X, y = data
+
+        history_before = net_fit.history
+
+        p = tmpdir.mkdir('skorch').join('history.json')
+        with open(str(p), 'w') as f:
+            net_fit.save_history(f)
+        del net_fit
+        with open(str(p), 'r') as f:
+            net.load_history(f)
+
+        assert net.history == history_before
+
+    def test_save_load_history_file_str(
+            self, net_cls, module_cls, net_fit, data, tmpdir):
+        net = net_cls(module_cls).initialize()
+        X, y = data
+
+        history_before = net_fit.history
+
+        p = tmpdir.mkdir('skorch').join('history.json')
+        net_fit.save_history(str(p))
+        del net_fit
+        net.load_history(str(p))
+
+        assert net.history == history_before
+
+    def test_save_load_history_file_path(
+            self, net_cls, module_cls, net_fit, data, tmpdir):
+        net = net_cls(module_cls).initialize()
+        X, y = data
+
+        history_before = net_fit.history
+
+        p = tmpdir.mkdir('skorch').join('history.json')
+        net_fit.save_history(Path(p))
+        del net_fit
+        net.load_history(Path(p))
+
+        assert net.history == history_before
     @pytest.mark.parametrize('method, call_count', [
         ('on_train_begin', 1),
         ('on_train_end', 1),

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -280,7 +280,7 @@ def noop(*args, **kwargs):
 
 @contextmanager
 def open_file_like(f, mode):
-    """Wrapper for opening a file and y"""
+    """Wrapper for opening a file"""
     new_fd = isinstance(f, str) or isinstance(f, pathlib.Path)
     if new_fd:
         f = open(f, mode)

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -5,14 +5,18 @@ Should not have any dependency on other skorch packages.
 """
 
 from collections.abc import Sequence
+from contextlib import contextmanager
 from enum import Enum
 from functools import partial
+import sys
 
 import numpy as np
 from sklearn.utils import safe_indexing
 import torch
 from torch import nn
 from torch.utils.data.dataset import Subset
+if sys.version_info[0] == 3:
+    import pathlib
 
 
 class Ansi(Enum):
@@ -274,3 +278,18 @@ def noop(*args, **kwargs):
     target extractor.
     """
     pass
+
+
+@contextmanager
+def _with_file_like(f, mode):
+    new_fd = False
+    if (
+        isinstance(f, str) or
+        sys.version_info[0] == 2 and isinstance(f, unicode) or
+        sys.version_info[0] == 3 and isinstance(f, pathlib.Path)
+    ):
+        new_fd = True
+        f = open(f, mode)
+    yield f
+    if new_fd:
+        f.close()

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -8,15 +8,13 @@ from collections.abc import Sequence
 from contextlib import contextmanager
 from enum import Enum
 from functools import partial
-import sys
+import pathlib
 
 import numpy as np
 from sklearn.utils import safe_indexing
 import torch
 from torch import nn
 from torch.utils.data.dataset import Subset
-if sys.version_info[0] == 3:
-    import pathlib
 
 
 class Ansi(Enum):
@@ -281,15 +279,13 @@ def noop(*args, **kwargs):
 
 
 @contextmanager
-def _with_file_like(f, mode):
-    new_fd = False
-    if (
-        isinstance(f, str) or
-        sys.version_info[0] == 2 and isinstance(f, unicode) or
-        sys.version_info[0] == 3 and isinstance(f, pathlib.Path)
-    ):
-        new_fd = True
-        f = open(f, mode)
-    yield f
+def open_file_like(f, mode):
+    """Wrapper for opening a file and y"""
+    new_fd = isinstance(f, str) or isinstance(f, pathlib.Path)
     if new_fd:
-        f.close()
+        f = open(f, mode)
+    try:
+        yield f
+    finally:
+        if new_fd:
+            f.close()


### PR DESCRIPTION
Adds saving and loading history from a `NeutralNet`.

This feature can be used by:

```python
before = NeuralNetClassifier(mymodule)
before.save_history('history.json')
before.fit(X, y)
after = NeuralNetClassifier(mymodule).initialize()
after.load_history('history.json')
```

Use Cases:

1. A user wants to continue training a `NeutralNet` while keeping the history of the previous run. This allows for `LRScheduler` to work correctly during the second run, since `LRScheduler` relies on `len(history)`.
2. After training is finished, the `history.json` file can be used to analyze the run.