### PR TITLE
BUG: Fixes off by one batch index

### DIFF
--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -95,7 +95,7 @@ class LRScheduler(Callback):
         if not net.history:
             return -1
         epoch = len(net.history) - 1
-        current_batch_idx = len(net.history[-1, 'batches'])
+        current_batch_idx = len(net.history[-1, 'batches']) - 1
         batch_cnt = len(net.history[-2, 'batches']) if epoch >= 1 else 0
         return epoch * batch_cnt + current_batch_idx
 

--- a/skorch/tests/test_lr_scheduler.py
+++ b/skorch/tests/test_lr_scheduler.py
@@ -97,7 +97,7 @@ class TestLRCallbacks:
         net = NeuralNetClassifier(classifier_module(), max_epochs=max_epochs,
                                   batch_size=batch_size, callbacks=[lr_policy])
         net.fit(X, y)
-        expected = (num_examples // batch_size) * max_epochs
+        expected = (num_examples // batch_size) * max_epochs - 1
         # pylint: disable=protected-access
         assert lr_policy.lr_scheduler_.last_batch_idx == expected
 


### PR DESCRIPTION
The batch index should be zero indexed. Consider the following learning rate evolution of `CyclicLR`:

![screen shot](https://user-images.githubusercontent.com/5402633/40460019-9d3d8c1e-5ed2-11e8-8e91-263d0e270d2a.png)

This PR moves the starting point from the red dot to the gray dot (on the bottom left).