### PR TITLE
API: Removes device casting from Dataset

### DIFF
--- a/docs/user/dataset.rst
+++ b/docs/user/dataset.rst
@@ -126,18 +126,11 @@ have an ``X`` and a ``y``, where ``X`` represents the input data and
 ``y`` the target. However, you may leave ``y=None``, in which case
 :class:`.Dataset` returns a dummy variable.
 
-In contrast to a PyTorch :class:`~torch.utils.data.Dataset`, a skorch
-:class:`.Dataset` must have a ``device`` argument, which determines
-whether the returned data should be transferred to a specific
-computation device. Should you write your own :class:`.Dataset`
-subclass, remember to integrate this argument.
-
 :class:`.Dataset` applies a transform final transform on the data
 before passing it on to the PyTorch
-:class:`~torch.utils.data.DataLoader`. By default, it casts the data
-to a PyTorch :class:`~torch.Tensor` and replaces ``y`` by a dummy
-variable in case it is ``None``. If you would like to apply your own
-transformation on the data, you should subclass :class:`.Dataset` and
-override the :func:`~skorch.dataset.Dataset.transform` method, then
-pass your custom class to :class:`.NeuralNet` as the ``dataset``
-argument.
+:class:`~torch.utils.data.DataLoader`. By default, it replaces ``y``
+by a dummy variable in case it is ``None``. If you would like to
+apply your own transformation on the data, you should subclass
+:class:`.Dataset` and override the
+:func:`~skorch.dataset.Dataset.transform` method, then pass your
+custom class to :class:`.NeuralNet` as the ``dataset`` argument.

--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -268,10 +268,6 @@ CUDA before being passed to the PyTorch :class:`~torch.nn.Module`. The
 device parameter adheres to the general syntax of the PyTorch device
 parameter.
 
-Among other things, ``device`` is passed to :class:`.Dataset` when it
-is initialized, but if you set ``dataset__device`` explicitely, the
-latter will have precedence.
-
 initialize()
 ^^^^^^^^^^^^
 

--- a/skorch/dataset.py
+++ b/skorch/dataset.py
@@ -15,7 +15,6 @@ from skorch.utils import flatten
 from skorch.utils import is_pandas_ndframe
 from skorch.utils import multi_indexing
 from skorch.utils import to_numpy
-from skorch.utils import to_tensor
 
 
 def _apply_to_data(data, func, unpack_dict=False):
@@ -73,9 +72,6 @@ class Dataset(torch.utils.data.Dataset):
     y : see above or None (default=None)
       Everything pertaining to the target, if there is anything.
 
-    device : str, torch.device (default='cpu')
-      Which computation device to use (e.g., 'cuda').
-
     length : int or None (default=None)
       If not None, determines the length (``len``) of the data. Should
       usually be left at None, in which case the length is determined
@@ -86,12 +82,10 @@ class Dataset(torch.utils.data.Dataset):
             self,
             X,
             y=None,
-            device='cpu',
             length=None,
     ):
         self.X = X
         self.y = y
-        self.device = device
 
         if length is not None:
             self._len = length
@@ -132,10 +126,7 @@ class Dataset(torch.utils.data.Dataset):
         # FIXME:: since this value may look meaningful.
         y = torch.Tensor([0]) if y is None else y
 
-        return (
-            to_tensor(X, device=self.device),
-            to_tensor(y, device=self.device),
-        )
+        return X, y
 
     def __getitem__(self, i):
         X, y = self.X, self.y

--- a/skorch/dataset.py
+++ b/skorch/dataset.py
@@ -2,6 +2,7 @@
 
 from functools import partial
 from numbers import Number
+import warnings
 
 import numpy as np
 from sklearn.model_selection import ShuffleSplit
@@ -82,8 +83,15 @@ class Dataset(torch.utils.data.Dataset):
             self,
             X,
             y=None,
+            device=None,
             length=None,
     ):
+        # TODO: Remove warning in a future release
+        if device is not None:
+            warnings.warn(
+                "device is no longer needed by Dataset and will be ignored.",
+                DeprecationWarning)
+
         self.X = X
         self.y = y
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -120,14 +120,11 @@ class NeuralNet(object):
       pytorch's ``DataLoader``. It has to implement the ``__len__`` and
       ``__getitem__`` methods. The provided dataset should be capable of
       dealing with a lot of data types out of the box, so only change
-      this if your data is not supported. Additionally, dataset should
-      accept a ``device`` parameter to indicate the location of the
-      data (e.g., CUDA).
-      You should generally pass the uninitialized ``Dataset`` class
-      and define additional arguments to X and y by prefixing them
-      with ``dataset__``. It is also possible to pass an initialzed
-      ``Dataset``, in which case no additional arguments may be
-      passed.
+      this if your data is not supported. You should generally pass the
+      uninitialized ``Dataset`` class and define additional arguments to
+      X and y by prefixing them with ``dataset__``. It is also possible
+      to pass an initialzed ``Dataset``, in which case no additional
+      arguments may be passed.
 
     train_split : None or callable (default=skorch.dataset.CVSplit(5))
       If None, there is no train/validation split. Else, train_split
@@ -918,8 +915,6 @@ class NeuralNet(object):
         Override this if you want to initialize your dataset
         differently.
 
-        If ``dataset__device`` is not set, use ``self.device`` instead.
-
         Parameters
         ----------
         X : input data, compatible with skorch.dataset.Dataset
@@ -960,9 +955,6 @@ class NeuralNet(object):
 
         if is_initialized:
             return dataset
-
-        if 'device' not in kwargs:
-            kwargs['device'] = self.device
 
         return dataset(X, y, **kwargs)
 

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -821,15 +821,6 @@ class TestNeuralNet:
         # anymore
         net.fit(*data)  # should not raise
 
-    def test_net_initialized_with_partialed_dataset(
-            self, net_cls, module_cls, data, dataset_cls):
-        net = net_cls(
-            module_cls,
-            dataset=partial(dataset_cls, device='cpu'),
-            max_epochs=1,
-        )
-        net.fit(*data)  # does not raise
-
     def test_net_initialized_with_initalized_dataset_and_kwargs_raises(
             self, net_cls, module_cls, data, dataset_cls):
         net = net_cls(

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -63,8 +63,7 @@ def to_tensor(X, device):
         X = torch.tensor(X)
 
     if np.isscalar(X):
-        # ugly work-around - torch constructor does not accept np scalars
-        X = torch.tensor(np.array([X]))[0]
+        X = torch.tensor(X)
 
     if isinstance(X, Sequence):
         X = torch.tensor(np.array(X))

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -50,28 +50,22 @@ def to_tensor(X, device):
         "Set `device='cuda'` instead.")
     to_tensor_ = partial(to_tensor, device=device)
 
-    if isinstance(X, nn.utils.rnn.PackedSequence):
-        return X
-
-    if isinstance(X, dict):
+    if is_torch_data_type(X):
+        return X.to(device)
+    elif np.isscalar(X):
+        return torch.tensor(X).to(device)
+    elif isinstance(X, dict):
         return {key: to_tensor_(val) for key, val in X.items()}
-
-    if isinstance(X, (list, tuple)):
+    elif isinstance(X, (list, tuple)):
         return [to_tensor_(x) for x in X]
-
-    if isinstance(X, np.ndarray):
-        X = torch.tensor(X)
-
-    if np.isscalar(X):
-        X = torch.tensor(X)
-
-    if isinstance(X, Sequence):
-        X = torch.tensor(np.array(X))
-
-    if not is_torch_data_type(X):
+    elif isinstance(X, Sequence):
+        return torch.tensor(np.array(X)).to(device)
+    elif isinstance(X, np.ndarray):
+        return torch.tensor(X).to(device)
+    elif isinstance(X, nn.utils.rnn.PackedSequence):
+        return X
+    else:
         raise TypeError("Cannot convert this data type to a torch tensor.")
-
-    return X.to(device)
 
 
 def to_numpy(X):

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -52,12 +52,12 @@ def to_tensor(X, device):
 
     if is_torch_data_type(X):
         return X.to(device)
-    elif np.isscalar(X):
-        return torch.tensor(X).to(device)
     elif isinstance(X, dict):
         return {key: to_tensor_(val) for key, val in X.items()}
     elif isinstance(X, (list, tuple)):
         return [to_tensor_(x) for x in X]
+    elif np.isscalar(X):
+        return torch.tensor(X).to(device)
     elif isinstance(X, Sequence):
         return torch.tensor(np.array(X)).to(device)
     elif isinstance(X, np.ndarray):


### PR DESCRIPTION
Resolves https://github.com/dnouri/skorch/issues/223.

1. Removes `to_tensor` and `self.device` from `Dataset`.

2. `torch.utils.data.DataLoader`'s `collate_fn=default_collate` function is able to handle our types without needing to covert them to tensors first. During training, validation, or evaluation, `NeuralNet.get_loss` and `NeuralNet.infer` will call `to_tensor` to move data to `self.device`.

3. When `X` and `y` are yielded from a `DataLoader`, their numerical values are already converted into tensors. `get_loss` and `infer` will call `to_tensor` with tensor-filled `X` and `y` values.  With this in mind, I refactored `to_tensor` to check the tensor type first and return early.

This PR frees `Dataset` from worrying about `device` and allows `NeutralNet` to handle device transfers. This makes `Dataset` be inline with datasets in `torchvision.datasets`, which doesn't involve the GPU when yielding data.