### PR TITLE
ENH: Adds NeuralNetBinaryClassifier

### DIFF
--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -202,7 +202,11 @@ neural_net_binary_clf_criterion_text = """
 
     criterion : torch criterion (class, default=torch.nn.BCEWithLogitsLoss)
       Binary cross entropy loss with logits. Note that the module should return
-      the logit of probabilities with shape (batch_size, )."""
+      the logit of probabilities with shape (batch_size, ).
+
+    threshold : float (default=0.5)
+      Probabilities above this threshold is classified as 1. ``threshold``
+      is used by ``predict`` and ``predict_proba`` for classification."""
 
 
 def get_neural_net_binary_clf_doc(doc):
@@ -222,6 +226,7 @@ class NeuralNetBinaryClassifier(NeuralNet):
             module,
             criterion=torch.nn.BCEWithLogitsLoss,
             train_split=CVSplit(5, stratified=True),
+            threshold=0.5,
             *args,
             **kwargs
     ):
@@ -232,6 +237,7 @@ class NeuralNetBinaryClassifier(NeuralNet):
             *args,
             **kwargs
         )
+        self.threshold = threshold
 
     @property
     def _default_callbacks(self):
@@ -277,7 +283,7 @@ class NeuralNetBinaryClassifier(NeuralNet):
         # https://github.com/PyCQA/pylint/issues/1085
         return super().fit(X, y, **fit_params)
 
-    def predict(self, X, threshold=0.5):
+    def predict(self, X):
         """Where applicable, return class labels for samples in X.
 
         If the module's forward method returns multiple outputs as a
@@ -306,7 +312,7 @@ class NeuralNetBinaryClassifier(NeuralNet):
         y_pred : numpy ndarray
 
         """
-        return (self.predict_proba(X) > threshold).astype('uint8')
+        return (self.predict_proba(X) > self.threshold).astype('uint8')
 
     # pylint: disable=missing-docstring
     def predict_proba(self, X):

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -224,10 +224,10 @@ class NeuralNetBinaryClassifier(NeuralNet):
     def __init__(
             self,
             module,
+            *args,
             criterion=torch.nn.BCEWithLogitsLoss,
             train_split=CVSplit(5, stratified=True),
             threshold=0.5,
-            *args,
             **kwargs
     ):
         super().__init__(

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -275,7 +275,7 @@ class NeuralNetBinaryClassifier(NeuralNet):
         # pylint: disable=useless-super-delegation
         # this is actually a pylint bug:
         # https://github.com/PyCQA/pylint/issues/1085
-        return super(NeuralNetBinaryClassifier, self).fit(X, y, **fit_params)
+        return super().fit(X, y, **fit_params)
 
     def predict(self, X, threshold=0.5):
         """Where applicable, return class labels for samples in X.

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -346,9 +346,13 @@ class NeuralNetBinaryClassifier(NeuralNet):
 
         """
         y_probas = []
+        bce_logits_loss = isinstance(
+            self.criterion_, torch.nn.BCEWithLogitsLoss)
+
         for yp in self.forward_iter(X, training=False):
             yp = yp[0] if isinstance(yp, tuple) else yp
-            yp = torch.nn.functional.sigmoid(yp)
+            if bce_logits_loss:
+                yp = torch.nn.functional.sigmoid(yp)
             y_probas.append(to_numpy(yp))
         y_proba = np.concatenate(y_probas, 0)
         return y_proba

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -22,7 +22,7 @@ class TestCheckpoint:
     @pytest.fixture
     def net_cls(self):
         """very simple network that trains for 10 epochs"""
-        from skorch import NeuralNetRegressor
+        from skorch.net import NeuralNetRegressor
         import torch
 
         class Module(torch.nn.Module):

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -22,7 +22,7 @@ class TestCheckpoint:
     @pytest.fixture
     def net_cls(self):
         """very simple network that trains for 10 epochs"""
-        from skorch.net import NeuralNetRegressor
+        from skorch import NeuralNetRegressor
         import torch
 
         class Module(torch.nn.Module):

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -186,16 +186,19 @@ class TestNeuralNetBinaryClassifier:
         for row in net_fit.history:
             assert expected_keys.issubset(row)
 
-    @pytest.mark.parametrize('threshold', [0, 0.5, 1])
-    def test_predict_predict_proba(self, net_fit, data, threshold):
-        X = data[0]
-        y_pred_proba = net_fit.predict_proba(X)
+    @pytest.mark.parametrize('threshold', [0, 0.25, 0.5, 0.75, 1])
+    def test_predict_predict_proba(self, net, data, threshold):
+        X, y = data
+        net.threshold = threshold
+        net.fit(X, y)
+
+        y_pred_proba = net.predict_proba(X)
         assert len(y_pred_proba.shape) == 1
         assert y_pred_proba.shape[0] == X.shape[0]
 
         y_pred_exp = (y_pred_proba > threshold).astype('uint8')
 
-        y_pred_actual = net_fit.predict(X, threshold=threshold)
+        y_pred_actual = net.predict(X)
         assert np.allclose(y_pred_exp, y_pred_actual)
 
     def test_target_2d_raises(self, net, data):

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -117,3 +117,90 @@ class TestNeuralNet:
         for (y_out, _), _ in mock_loss.call_args_list:
             assert not (y_out < 0).all()
             assert torch.isclose(torch.ones(len(y_out)), y_out.sum(1)).all()
+
+
+class MyBinaryClassifier(nn.Module):
+    """Simple binary classification module.
+
+    We cannot use the module fixtures from conftest because they are
+    not pickleable.
+
+    """
+
+    def __init__(self, num_units=10, nonlin=F.relu):
+        super().__init__()
+
+        self.dense0 = nn.Linear(20, num_units)
+        self.nonlin = nonlin
+        self.dropout = nn.Dropout(0.5)
+        self.dense1 = nn.Linear(num_units, 10)
+        self.output = nn.Linear(10, 1)
+
+    # pylint: disable=arguments-differ
+    def forward(self, X):
+        X = self.nonlin(self.dense0(X))
+        X = self.dropout(X)
+        X = self.nonlin(self.dense1(X))
+        X = self.output(X).squeeze_(-1)
+        return X
+
+
+class TestNeuralNetBinaryClassifier:
+    @pytest.fixture(scope='module')
+    def data(self, classifier_data):
+        X, y = classifier_data
+        return X, y.astype('float32')
+
+    @pytest.fixture(scope='module')
+    def module_cls(self):
+        return MyBinaryClassifier
+
+    @pytest.fixture(scope='module')
+    def net_cls(self):
+        from skorch.classifier import NeuralNetBinaryClassifier
+        return NeuralNetBinaryClassifier
+
+    @pytest.fixture(scope='module')
+    def net(self, net_cls, module_cls):
+        return net_cls(
+            module_cls,
+            max_epochs=20,
+            lr=0.1,
+        )
+
+    @pytest.fixture(scope='module')
+    def net_fit(self, net, data):
+        # Careful, don't call additional fits on this, since that would have
+        # side effects on other tests.
+        X, y = data
+        return net.fit(X, y)
+
+    def test_fit(self, net_fit):
+        # fitting does not raise anything
+        pass
+
+    def test_history_default_keys(self, net_fit):
+        expected_keys = {
+            'train_loss', 'valid_loss', 'epoch', 'dur', 'batches', 'valid_acc'
+        }
+        for row in net_fit.history:
+            assert expected_keys.issubset(row)
+
+    def test_predict_predict_proba(self, net_fit, data):
+        X = data[0]
+        y_pred_proba = net_fit.predict_proba(X)
+        assert len(y_pred_proba.shape) == 1
+        assert y_pred_proba.shape[0] == X.shape[0]
+
+        y_pred_exp = (y_pred_proba > 0.5).astype('uint8')
+
+        y_pred_actual = net_fit.predict(X)
+        assert np.allclose(y_pred_exp, y_pred_actual)
+
+    def test_target_2d_raises(self, net, data):
+        X, y = data
+        with pytest.raises(ValueError) as exc:
+            net.fit(X, y[:, None])
+
+        assert exc.value.args[0] == (
+            "The target data should be 1-dimensional.")

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -164,7 +164,7 @@ class TestNeuralNetBinaryClassifier:
     def net(self, net_cls, module_cls):
         return net_cls(
             module_cls,
-            max_epochs=20,
+            max_epochs=1,
             lr=0.1,
         )
 
@@ -214,21 +214,21 @@ class TestNeuralNetBinaryClassifier:
         mock = Mock(side_effect=lambda x: x)
         monkeypatch.setattr(torch.nn.functional, "sigmoid", mock)
 
-        net = net_cls(module_cls, max_epochs=20, lr=0.1, criterion=nn.MSELoss)
+        net = net_cls(module_cls, max_epochs=1, lr=0.1, criterion=nn.MSELoss)
         X, y = data
         net.fit(X, y)
 
         net.predict_proba(X)
-        mock.assert_not_called()
+        assert mock.call_count == 0
 
-    def test_default_loss_does_calls_sigmoid(
+    def test_default_loss_does_call_sigmoid(
             self, net_cls, data, module_cls, monkeypatch):
         mock = Mock(side_effect=lambda x: x)
         monkeypatch.setattr(torch.nn.functional, "sigmoid", mock)
 
-        net = net_cls(module_cls, max_epochs=20, lr=0.1)
+        net = net_cls(module_cls, max_epochs=1, lr=0.1)
         X, y = data
         net.fit(X, y)
 
         net.predict_proba(X)
-        mock.assert_called()
+        assert mock.call_count > 0

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -186,15 +186,16 @@ class TestNeuralNetBinaryClassifier:
         for row in net_fit.history:
             assert expected_keys.issubset(row)
 
-    def test_predict_predict_proba(self, net_fit, data):
+    @pytest.mark.parametrize('threshold', [0, 0.5, 1])
+    def test_predict_predict_proba(self, net_fit, data, threshold):
         X = data[0]
         y_pred_proba = net_fit.predict_proba(X)
         assert len(y_pred_proba.shape) == 1
         assert y_pred_proba.shape[0] == X.shape[0]
 
-        y_pred_exp = (y_pred_proba > 0.5).astype('uint8')
+        y_pred_exp = (y_pred_proba > threshold).astype('uint8')
 
-        y_pred_actual = net_fit.predict(X)
+        y_pred_actual = net_fit.predict(X, threshold=threshold)
         assert np.allclose(y_pred_exp, y_pred_actual)
 
     def test_target_2d_raises(self, net, data):

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -208,3 +208,27 @@ class TestNeuralNetBinaryClassifier:
 
         assert exc.value.args[0] == (
             "The target data should be 1-dimensional.")
+
+    def test_custom_loss_does_not_call_sigmoid(
+            self, net_cls, data, module_cls, monkeypatch):
+        mock = Mock(side_effect=lambda x: x)
+        monkeypatch.setattr(torch.nn.functional, "sigmoid", mock)
+
+        net = net_cls(module_cls, max_epochs=20, lr=0.1, criterion=nn.MSELoss)
+        X, y = data
+        net.fit(X, y)
+
+        net.predict_proba(X)
+        mock.assert_not_called()
+
+    def test_default_loss_does_calls_sigmoid(
+            self, net_cls, data, module_cls, monkeypatch):
+        mock = Mock(side_effect=lambda x: x)
+        monkeypatch.setattr(torch.nn.functional, "sigmoid", mock)
+
+        net = net_cls(module_cls, max_epochs=20, lr=0.1)
+        X, y = data
+        net.fit(X, y)
+
+        net.predict_proba(X)
+        mock.assert_called()

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -193,7 +193,7 @@ class TestNeuralNetBinaryClassifier:
         net.fit(X, y)
 
         y_pred_proba = net.predict_proba(X)
-        assert len(y_pred_proba.shape) == 1
+        assert y_pred_proba.ndim == 1
         assert y_pred_proba.shape[0] == X.shape[0]
 
         y_pred_exp = (y_pred_proba > threshold).astype('uint8')


### PR DESCRIPTION
Resolves #200. I made the following design choices when creating `NeuralNetBinaryClassifier`:

1. Uses `BCEWithLogitsLoss` by default, which means `self.module` must output the logit of probability. Based on the pytorch documentation, `BCEWithLogitsLoss` is more numerical stable to use than `BCELoss`.

2. `self.module` is expected to output values with shape: (`batch_size`, ). I am open to changing this to (`batch_size`, 1).

3. Subclassed `NeuralNetClassifier` since the `predict`, `predict_proba`, and `fit` docstrings are relevant for  `NeuralNetBinaryClassifier`. 

4. `NeuralNetClassifier.check_data` is reused, combined with a check on the y's dimension.

5. I had to override `get_loss` and use `NeuralNet.get_loss` instead. In its current form, `NeuralNetBinaryClassifier` should not need to take the log of any values. This is the downside of subclassing `NeuralNetClassifier`.