### PR TITLE
Support optimizers requiring closures - v2

### DIFF
--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1325,6 +1325,12 @@ class TestNeuralNet:
             assert not (y_out < 0).all()
             assert torch.isclose(torch.ones(len(y_out)), y_out.sum(1)).all()
 
+    def test_fit_lbfgs_optimizer(self, net, data):
+        X, y = data
+        net.set_params(optimizer=torch.optim.LBFGS)
+        net.set_params(batch_size=len(X))
+        net.fit(X, y)
+
 
 class MyRegressor(nn.Module):
     """Simple regression module.
@@ -1414,3 +1420,6 @@ class TestNeuralNetRegressor:
         y_proba = net_fit.predict_proba(X)
         # predict and predict_proba should be identical for regression
         assert np.allclose(y_pred, y_proba, atol=1e-6)
+
+
+

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -377,3 +377,19 @@ def open_file_like(f, mode):
     finally:
         if new_fd:
             f.close()
+
+
+class StoreFirstValue:
+    """
+    The class saves the argument of the first `store` call, to later be
+    retrieved by `get()`
+    """
+    def __init__(self):
+        self.data = None
+
+    def store(self, data):
+        if self.data is None:
+            self.data = data
+
+    def get(self):
+        return self.data


### PR DESCRIPTION
Should resolve issue #207 
Based on PR #211 - including work by @ottonemo and @benjamin-work 

I have experimented a bit with how to implement it. This option seems the least awkward.

Why not have a function that calculates y_pred, loss, and updates the gradient + a class that wraps it and records first values of y_pred and loss?
- because the wrapper class has to be aware of how values of y_pred, loss, and optionally also Xi,yi, fit_params are passed around. Not generic and does not encapsulate anything.

About backward compatibility and what should be called `train_step`:
- I really think the "outer" step should be called that, as it does what it used to: calculate gradients and run an optimizer step(update model parameters). 

The inner step function just prepares some values - loss, gradients - does not update the model, even though it shares more code with the old `train_step`

I actually have another implementation stashed for this issue, with a separate "inner train step" function and a "closure" class (called differently) 

@ottonemo  if you think that this PR makes changing some parts of NeuralNet logic too cumbersome - I can post this alternative PR.

Please comment! 
Regards