### PR TITLE
Add support for configurable sink in Checkpoint

### DIFF
--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -56,14 +56,21 @@ class Checkpoint(Callback):
       **Note:** If you supply a lambda expression as monitor, you cannot
       pickle the wrapper anymore as lambdas cannot be pickled. You can
       mitigate this problem by using importable functions instead.
+
+    sink : callable (default=print)
+      The target that the information about created checkpoints is
+      sent to. By default, the output is printed to stdout, but the
+      sink could also be a logger or :func:`~skorch.utils.noop`.
     """
     def __init__(
             self,
             target='model.pt',
             monitor='valid_loss_best',
+            sink=print,
     ):
         self.monitor = monitor
         self.target = target
+        self.sink = sink
 
     def on_epoch_end(self, net, **kwargs):
         if self.monitor is None:
@@ -87,6 +94,10 @@ class Checkpoint(Callback):
                     last_epoch=net.history[-1],
                     last_batch=net.history[-1, 'batches', -1],
                 )
-            if net.verbose > 0:
-                print("Checkpoint! Saving model to {}.".format(target))
+            self._sink("Checkpoint! Saving model to {}.".format(target), net.verbose)
             net.save_params(target)
+
+    def _sink(self, text, verbose):
+        #  We do not want to be affected by verbosity if sink is not print
+        if (self.sink is not print) or verbose:
+            self.sink(text)

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -1,5 +1,6 @@
 
 from functools import partial
+from unittest.mock import Mock
 from unittest.mock import patch
 
 import numpy as np
@@ -48,12 +49,14 @@ class TestCheckpoint:
 
     def test_none_monitor_saves_always(
             self, save_params_mock, net_cls, checkpoint_cls, data):
+        sink = Mock()
         net = net_cls(callbacks=[
-            checkpoint_cls(monitor=None),
+            checkpoint_cls(monitor=None, sink=sink),
         ])
         net.fit(*data)
 
         assert save_params_mock.call_count == len(net.history)
+        assert sink.call_count == len(net.history)
 
     def test_default_without_validation_raises_meaningful_error(
             self, net_cls, checkpoint_cls, data):
@@ -83,13 +86,16 @@ class TestCheckpoint:
         scoring = EpochScoring(
             scoring=epoch_3_scorer, on_train=True)
 
+        sink = Mock()
         net = net_cls(callbacks=[
             ('my_score', scoring),
             checkpoint_cls(
                 monitor='epoch_3_scorer',
-                target='model_{last_epoch[epoch]}_{net.max_epochs}.pt'),
+                target='model_{last_epoch[epoch]}_{net.max_epochs}.pt',
+                sink=sink),
         ])
         net.fit(*data)
 
         assert save_params_mock.call_count == 1
         save_params_mock.assert_called_with('model_3_10.pt')
+        assert sink.call_count == 1


### PR DESCRIPTION
Partially addresses #246.

I'm not particularly confident with unit testing in Python, so I probably did something wrong, please let me know.