### PR TITLE
DOC: Update deps to fix syntax highlighting

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.13.3
 http://download.pytorch.org/whl/cpu/torch-0.4.0-cp35-cp35m-linux_x86_64.whl
-sphinx-rtd-theme==0.2.4
-numpydoc==0.7.0
+sphinx-rtd-theme==0.4.0
+numpydoc==0.8.0


### PR DESCRIPTION
Updating the dependencies for doc building fixes syntax highlighting on readthedocs.

I tested this out by building this branch on readthedocs:

- **Before**: https://skorch.readthedocs.io/en/latest/user/quickstart.html#
- **After**: https://skorch-doc-test.readthedocs.io/en/doc-sytnax-fix/user/quickstart.html

Overall, there are little style changes that increases the contrast of elements.