### PR TITLE
ENH: Adds more step_size control CyclicLR

### DIFF
--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -310,7 +310,7 @@ class TestCyclicLR():
     def test_triangular_mode(self, init_optimizer, num_groups):
         target = [1, 2, 3, 4, 5, 4, 3, 2, 1, 2, 3]
         targets = [target] * num_groups
-        scheduler = CyclicLR(init_optimizer, base_lr=1, max_lr=5, step_size=4,
+        scheduler = CyclicLR(init_optimizer, base_lr=1, max_lr=5, step_size_up=4,
                              mode='triangular')
         self._test_cycle_lr(init_optimizer, scheduler, targets)
 
@@ -318,8 +318,8 @@ class TestCyclicLR():
         target = [1, 2, 3, 4, 5, 13/3, 11/3, 9/3, 7/3, 5/3, 1]
         targets = [target] * num_groups
         scheduler = CyclicLR(init_optimizer, base_lr=1, max_lr=5,
-                             step_size=4,
-                             step_size_2=6,
+                             step_size_up=4,
+                             step_size_down=6,
                              mode='triangular')
         self._test_cycle_lr(init_optimizer, scheduler, targets)
 
@@ -332,7 +332,7 @@ class TestCyclicLR():
         max_lrs = [5 + delta for delta in deltas]
         targets = [[x + delta for x in base_target] for delta in deltas]
         scheduler = CyclicLR(init_optimizer, base_lr=base_lrs, max_lr=max_lrs,
-                             step_size=4, mode='triangular2')
+                             step_size_up=4, mode='triangular2')
         self._test_cycle_lr(init_optimizer, scheduler, targets)
 
     def test_triangular2_mode_step_size_2(self, init_optimizer, num_groups):
@@ -344,7 +344,7 @@ class TestCyclicLR():
         max_lrs = [5 + delta for delta in deltas]
         targets = [[x + delta for x in base_target] for delta in deltas]
         scheduler = CyclicLR(init_optimizer, base_lr=base_lrs, max_lr=max_lrs,
-                             step_size=2, step_size_2=6,
+                             step_size_up=2, step_size_down=6,
                              mode='triangular2')
         self._test_cycle_lr(init_optimizer, scheduler, targets)
 
@@ -357,7 +357,7 @@ class TestCyclicLR():
         target = [base_lr + x*diff_lr*gamma**i for i, x in enumerate(xs)]
         targets = [target] * num_groups
         scheduler = CyclicLR(init_optimizer, base_lr=base_lr, max_lr=max_lr,
-                             step_size=4, mode='exp_range', gamma=gamma)
+                             step_size_up=4, mode='exp_range', gamma=gamma)
         self._test_cycle_lr(init_optimizer, scheduler, targets)
 
     def test_exp_range_mode_step_size_2(self, init_optimizer, num_groups):
@@ -368,7 +368,7 @@ class TestCyclicLR():
         target = [base_lr + x*diff_lr*gamma**i for i, x in enumerate(xs)]
         targets = [target] * num_groups
         scheduler = CyclicLR(init_optimizer, base_lr=base_lr, max_lr=max_lr,
-                             step_size=2, step_size_2=6,
+                             step_size_up=2, step_size_down=6,
                              mode='exp_range', gamma=gamma)
         self._test_cycle_lr(init_optimizer, scheduler, targets)
 

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -314,6 +314,16 @@ class TestCyclicLR():
                              mode='triangular')
         self._test_cycle_lr(init_optimizer, scheduler, targets)
 
+    def test_triangular_mode_different_step_size(self, init_optimizer, num_groups):
+        target = [1, 2, 3, 4, 5, 4 + 1/3,
+                  3 + 2/3, 3, 2 + 1/3, 1 + 2/3, 1]
+        targets = [target] * num_groups
+        scheduler = CyclicLR(init_optimizer, base_lr=1, max_lr=5,
+                             step_size=4,
+                             step_size_2=6,
+                             mode='triangular')
+        self._test_cycle_lr(init_optimizer, scheduler, targets)
+
     def test_triangular2_mode(self, init_optimizer, num_groups):
         base_target = ([1, 2, 3, 4, 5, 4, 3, 2, 1,
                         1.5, 2.0, 2.5, 3.0, 2.5, 2.0, 1.5, 1,

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -314,9 +314,8 @@ class TestCyclicLR():
                              mode='triangular')
         self._test_cycle_lr(init_optimizer, scheduler, targets)
 
-    def test_triangular_mode_different_step_size(self, init_optimizer, num_groups):
-        target = [1, 2, 3, 4, 5, 4 + 1/3,
-                  3 + 2/3, 3, 2 + 1/3, 1 + 2/3, 1]
+    def test_triangular_mode_step_size_2(self, init_optimizer, num_groups):
+        target = [1, 2, 3, 4, 5, 13/3, 11/3, 9/3, 7/3, 5/3, 1]
         targets = [target] * num_groups
         scheduler = CyclicLR(init_optimizer, base_lr=1, max_lr=5,
                              step_size=4,
@@ -336,6 +335,19 @@ class TestCyclicLR():
                              step_size=4, mode='triangular2')
         self._test_cycle_lr(init_optimizer, scheduler, targets)
 
+    def test_triangular2_mode_step_size_2(self, init_optimizer, num_groups):
+        base_target = ([1, 3, 5, 13/3, 11/3, 9/3, 7/3, 5/3,
+                        1, 2, 3, 8/3, 7/3, 6/3, 5/3, 4/3,
+                        1, 3/2, 2, 11/6, 10/6, 9/6, 8/6, 7/6])
+        deltas = [2*i for i in range(0, num_groups)]
+        base_lrs = [1 + delta for delta in deltas]
+        max_lrs = [5 + delta for delta in deltas]
+        targets = [[x + delta for x in base_target] for delta in deltas]
+        scheduler = CyclicLR(init_optimizer, base_lr=base_lrs, max_lr=max_lrs,
+                             step_size=2, step_size_2=6,
+                             mode='triangular2')
+        self._test_cycle_lr(init_optimizer, scheduler, targets)
+
     def test_exp_range_mode(self, init_optimizer, num_groups):
         base_lr, max_lr = 1, 5
         diff_lr = max_lr - base_lr
@@ -346,6 +358,18 @@ class TestCyclicLR():
         targets = [target] * num_groups
         scheduler = CyclicLR(init_optimizer, base_lr=base_lr, max_lr=max_lr,
                              step_size=4, mode='exp_range', gamma=gamma)
+        self._test_cycle_lr(init_optimizer, scheduler, targets)
+
+    def test_exp_range_mode_step_size_2(self, init_optimizer, num_groups):
+        base_lr, max_lr = 1, 5
+        diff_lr = max_lr - base_lr
+        gamma = 0.9
+        xs = ([0, 0.5, 1, 5/6, 4/6, 3/6, 2/6, 1/6, 0, 0.5, 1, 5/6, 4/6])
+        target = [base_lr + x*diff_lr*gamma**i for i, x in enumerate(xs)]
+        targets = [target] * num_groups
+        scheduler = CyclicLR(init_optimizer, base_lr=base_lr, max_lr=max_lr,
+                             step_size=2, step_size_2=6,
+                             mode='exp_range', gamma=gamma)
         self._test_cycle_lr(init_optimizer, scheduler, targets)
 
     def test_batch_idx_with_none(self, init_optimizer):

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -314,7 +314,7 @@ class TestCyclicLR():
                              mode='triangular')
         self._test_cycle_lr(init_optimizer, scheduler, targets)
 
-    def test_triangular_mode_step_size_2(self, init_optimizer, num_groups):
+    def test_triangular_mode_step_size_up_down(self, init_optimizer, num_groups):
         target = [1, 2, 3, 4, 5, 13/3, 11/3, 9/3, 7/3, 5/3, 1]
         targets = [target] * num_groups
         scheduler = CyclicLR(init_optimizer, base_lr=1, max_lr=5,
@@ -335,7 +335,7 @@ class TestCyclicLR():
                              step_size_up=4, mode='triangular2')
         self._test_cycle_lr(init_optimizer, scheduler, targets)
 
-    def test_triangular2_mode_step_size_2(self, init_optimizer, num_groups):
+    def test_triangular2_mode_step_size_up_down(self, init_optimizer, num_groups):
         base_target = ([1, 3, 5, 13/3, 11/3, 9/3, 7/3, 5/3,
                         1, 2, 3, 8/3, 7/3, 6/3, 5/3, 4/3,
                         1, 3/2, 2, 11/6, 10/6, 9/6, 8/6, 7/6])
@@ -360,7 +360,7 @@ class TestCyclicLR():
                              step_size_up=4, mode='exp_range', gamma=gamma)
         self._test_cycle_lr(init_optimizer, scheduler, targets)
 
-    def test_exp_range_mode_step_size_2(self, init_optimizer, num_groups):
+    def test_exp_range_mode_step_size_up_down(self, init_optimizer, num_groups):
         base_lr, max_lr = 1, 5
         diff_lr = max_lr - base_lr
         gamma = 0.9


### PR DESCRIPTION
This PR includes an updated version of `CyclicLR` that allows more control of the step size. It adds an `step_size_2` to `CyclicLR`:

```python
    step_size : int (default=2000)
      Number of training iterations per for first half of a cycle.
      Authors suggest setting step_size 2-8 x training iterations in epoch.

    step_size_2 : int (default=None)
      Number of training iterations per for second half of a cycle.
      If step_size_2 is None, it is set to step_size.
```

For example with `step_size=3` and `step_size=17` the LR scheduling looks like this for one cycle:

![screen shot 2018-06-30 at 3 18 48 pm](https://user-images.githubusercontent.com/5402633/42128421-18e5d5ba-7c79-11e8-8ca2-633e8fee333e.JPG)

There was used in recent paper that uses this LR scheduler for language modeling: https://arxiv.org/abs/1801.06146, where this technique increases the rate of convergence. 