### PR TITLE
ENH: Scoring uses best score from history

### DIFF
--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -101,6 +101,9 @@ class ScoringBase(Callback):
     def on_train_begin(self, net, X, y, **kwargs):
         self.X_indexing_ = check_indexing(X)
         self.y_indexing_ = check_indexing(y)
+
+        # Looks for the right most index where `*_best` is True
+        # That index is used to get the best score in `net.history`
         with suppress(ValueError, IndexError):
             best_name_history = net.history[:, '{}_best'.format(self.name_)]
             idx_best_reverse = best_name_history[::-1].index(True)

--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -102,7 +102,8 @@ class ScoringBase(Callback):
         self.X_indexing_ = check_indexing(X)
         self.y_indexing_ = check_indexing(y)
         with suppress(ValueError, IndexError):
-            idx_best = net.history[:, f'{self.name_}_best'].index(True)
+            best_name = '{}_best'.format(self.name_)
+            idx_best = net.history[:, best_name].index(True)
             self.best_score_ = net.history[idx_best, self.name_]
 
     def _scoring(self, net, X_test, y_test):

--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -1,6 +1,7 @@
 """ Callbacks for calculating scores."""
 
 from contextlib import contextmanager
+from contextlib import suppress
 from functools import partial
 
 import numpy as np
@@ -100,6 +101,9 @@ class ScoringBase(Callback):
     def on_train_begin(self, net, X, y, **kwargs):
         self.X_indexing_ = check_indexing(X)
         self.y_indexing_ = check_indexing(y)
+        with suppress(ValueError, IndexError):
+            idx_best = net.history[:, f'{self.name_}_best'].index(True)
+            self.best_score_ = net.history[idx_best, self.name_]
 
     def _scoring(self, net, X_test, y_test):
         """Resolve scoring and apply it to data. Use cached prediction

--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -102,8 +102,9 @@ class ScoringBase(Callback):
         self.X_indexing_ = check_indexing(X)
         self.y_indexing_ = check_indexing(y)
         with suppress(ValueError, IndexError):
-            best_name = '{}_best'.format(self.name_)
-            idx_best = net.history[:, best_name].index(True)
+            best_name_history = net.history[:, '{}_best'.format(self.name_)]
+            idx_best_reverse = best_name_history[::-1].index(True)
+            idx_best = len(best_name_history) - idx_best_reverse - 1
             self.best_score_ = net.history[idx_best, self.name_]
 
     def _scoring(self, net, X_test, y_test):

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -85,9 +85,10 @@ class TestEpochScoring:
         (True, [True, True, True, False, False]),
         (False, [True, False, False, True, False]),
     ])
+    @pytest.mark.parametrize('initial_epochs', [1, 2, 3, 4])
     def test_scoring_uses_best_score_when_continuing_training(
         self, net_cls, module_cls, scoring_cls, train_split, data,
-        lower_is_better, expected, tmpdir
+        lower_is_better, expected, tmpdir, initial_epochs
     ):
         # set scoring to None so that mocked net.score is used
         net = net_cls(
@@ -95,7 +96,7 @@ class TestEpochScoring:
             callbacks=[scoring_cls(
                 scoring=None,
                 lower_is_better=lower_is_better)],
-            max_epochs=2,
+            max_epochs=initial_epochs,
             train_split=train_split,
         )
         net.fit(*data)
@@ -105,7 +106,7 @@ class TestEpochScoring:
 
         net.initialize()
         net.load_history(str(history_fn))
-        net.max_epochs = 3
+        net.max_epochs = 5 - initial_epochs
         net.partial_fit(*data)
 
         is_best = net.history[:, 'score_best']
@@ -554,9 +555,10 @@ class TestBatchScoring:
         (True, [True, True, True, False, False]),
         (False, [True, False, False, True, False]),
     ])
+    @pytest.mark.parametrize('initial_epochs', [1, 2, 3, 4])
     def test_scoring_uses_best_score_when_continuing_training(
         self, net_cls, module_cls, scoring_cls, train_split, data,
-        lower_is_better, expected, tmpdir
+        lower_is_better, expected, tmpdir, initial_epochs
     ):
         # set scoring to None so that mocked net.score is used
         net = net_cls(
@@ -564,7 +566,7 @@ class TestBatchScoring:
             callbacks=[scoring_cls(
                 scoring=None,
                 lower_is_better=lower_is_better)],
-            max_epochs=2,
+            max_epochs=initial_epochs,
             train_split=train_split,
         )
         net.fit(*data)
@@ -572,7 +574,7 @@ class TestBatchScoring:
         history_fn = tmpdir.mkdir('skorch').join('history.json')
         net.save_history(str(history_fn))
 
-        net.max_epochs = 3
+        net.max_epochs = 5 - initial_epochs
         net.initialize()
         net.load_history(str(history_fn))
         net.partial_fit(*data)


### PR DESCRIPTION
Fixes #267.

The scoring callbacks queries the history and updates `best_score_`  during `on_train_begin`.

This PR enables the following with proper `best_score_` tracking:

```python
net = NeuralNetClassifier(
    module_cls,
    ...
)
net.fit(X, y)
net.save_params('params.h5')
net.save_history('history.json')

net.initialize()
net.load_params('params.h5')
net.load_history('history.json')
net.partial_fit(X, y)
```