### PR TITLE
Suppress KeyErrors when trying to load best index from history

### DIFF
--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -104,7 +104,7 @@ class ScoringBase(Callback):
 
         # Looks for the right most index where `*_best` is True
         # That index is used to get the best score in `net.history`
-        with suppress(ValueError, IndexError):
+        with suppress(ValueError, IndexError, KeyError):
             best_name_history = net.history[:, '{}_best'.format(self.name_)]
             idx_best_reverse = best_name_history[::-1].index(True)
             idx_best = len(best_name_history) - idx_best_reverse - 1

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -95,9 +95,14 @@ class TestEpochScoring:
             module_cls,
             callbacks=[scoring_cls(
                 scoring=None,
+                on_train=True,
                 lower_is_better=lower_is_better)],
             max_epochs=initial_epochs,
-            train_split=train_split,
+            # Set train_split to None so that the default 'valid_loss'
+            # callback is effectively disabled and does not write to
+            # the history. This should not cause problems when trying
+            # to load best score for this scorer.
+            train_split=None,
         )
         net.fit(*data)
 
@@ -565,9 +570,14 @@ class TestBatchScoring:
             module_cls,
             callbacks=[scoring_cls(
                 scoring=None,
+                on_train=True,
                 lower_is_better=lower_is_better)],
             max_epochs=initial_epochs,
-            train_split=train_split,
+            # Set train_split to None so that the default 'valid_loss'
+            # callback is effectively disabled and does not write to
+            # the history. This should not cause problems when trying
+            # to load best score for this scorer.
+            train_split=None,
         )
         net.fit(*data)
 


### PR DESCRIPTION
(This fixes an issue introduced by #268.)

There might be a situation when history does not contain the column that the scoring callback writes to (and thus checks when loading).

Example: "valid_loss" scoring is added to the callback list by default, however it will not output anything to the history if there is no validation dataset (i.e. if `train_split=None`). Reloading such history will raise `KeyError`.

I updated the unit tests to reproduce exactly this situation. This updated test fails without the patch, and succeeds with.