### PR TITLE
Add support for 'event_' columns in history

### DIFF
--- a/docs/user/history.rst
+++ b/docs/user/history.rst
@@ -65,10 +65,10 @@ new epoch dictionary to the end of the list. Also, there is
 :func:`~skorch.history.History.new_batch` for adding new batches to
 the current epoch.
 
-To add a new item to the current epoch, use ``net.record('foo',
+To add a new item to the current epoch, use ``history.record('foo',
 123)``. This will set the value ``123`` for the key ``foo`` of the
 current epoch. To write a value to the current batch, use
-``net.record_batch('bar', 456)``. Below are some more examples:
+``history.record_batch('bar', 456)``. Below are some more examples:
 
 .. code:: python
 

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -78,6 +78,11 @@ class PrintLog(Callback):
       The number formatting. See the documentation of the ``tabulate``
       package for more details.
 
+    stralign : str (default='right')
+      The alignment of columns with strings. Can be 'left', 'center',
+      'right', or ``None`` (disable alignment). Default is 'right' (to
+      be consistent with numerical columns).
+
     """
     def __init__(
             self,
@@ -85,6 +90,7 @@ class PrintLog(Callback):
             sink=print,
             tablefmt='simple',
             floatfmt='.4f',
+            stralign='right',
     ):
         if isinstance(keys_ignored, str):
             keys_ignored = [keys_ignored]
@@ -92,6 +98,7 @@ class PrintLog(Callback):
         self.sink = sink
         self.tablefmt = tablefmt
         self.floatfmt = floatfmt
+        self.stralign = stralign
 
     def initialize(self):
         self.first_iteration_ = True
@@ -172,6 +179,7 @@ class PrintLog(Callback):
             headers=headers,
             tablefmt=self.tablefmt,
             floatfmt=self.floatfmt,
+            stralign=self.stralign,
         )
 
     def _sink(self, text, verbose):

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -35,7 +35,7 @@ class EpochTimer(Callback):
 
 
 class PrintLog(Callback):
-    """Print out useful information from the model's history.
+    """Print useful information from the model's history as a table.
 
     By default, ``PrintLog`` prints everything from the history except
     for ``'batches'``.
@@ -45,6 +45,14 @@ class PrintLog(Callback):
     ``'train_loss_best'`` will be matched with ``'train_loss'``. The
     ``Scoring`` callback takes care of creating those entries, which is
     why ``PrintLog`` works best in conjunction with that callback.
+
+    ``PrintLog`` treats keys with the ``'event_'`` prefix in a special
+    way. They are assumed to contain information about occasionally
+    occuring events. The ``False`` or ``None`` entries (indicating
+    that an event did not occur) are not printed, resulting in empty
+    cells in the table, and ``True`` entries are printed with ``+``
+    symbol. ``PrintLog`` groups all event columns together and pushes
+    them to the right, just before the ``'dur'`` column.
 
     *Note*: ``PrintLog`` will not result in good outputs if the number
     of columns varies between epochs, e.g. if the valid loss is only

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -58,6 +58,7 @@ class TestCheckpoint:
 
         assert save_params_mock.call_count == len(net.history)
         assert sink.call_count == len(net.history)
+        assert all((x is True) for x in net.history[:, 'event_cp'])
 
     def test_default_without_validation_raises_meaningful_error(
             self, net_cls, checkpoint_cls, data):
@@ -100,6 +101,9 @@ class TestCheckpoint:
         assert save_params_mock.call_count == 1
         save_params_mock.assert_called_with('model_3_10.pt')
         assert sink.call_count == 1
+        assert all((x is False) for x in net.history[:2, 'event_cp'])
+        assert net.history[2, 'event_cp'] is True
+        assert all((x is False) for x in net.history[3:, 'event_cp'])
 
 
 class TestEarlyStopping:
@@ -268,4 +272,3 @@ class TestEarlyStopping:
 
         expected_msg = "Invalid threshold mode: 'incorrect'"
         assert exc.value.args[0] == expected_msg
-


### PR DESCRIPTION
(This implements the ideas discussed in #246.)

`PrintLog` will output such columns on the right, just before 'dur'. When the value stored in history is True, a plus sign will be printed to the table. When the value stored in history is False or None, nothing will be printed, i.e. the cell will be empty.

The 'event_' prefix is stripped off from the key so as to not make the table header unnecessary long.