### PR TITLE
DOC: Adds transfer learning tutorial

### DIFF
--- a/notebooks/Transfer_learning.ipynb
+++ b/notebooks/Transfer_learning.ipynb
@@ -1,0 +1,369 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Transfer Learning with skorch\n",
+    "\n",
+    "In this tutorial, you will learn how to train a neutral network using transfer learning with the `skorch` API. Transfer learning uses a pretrained model to initialize a network. This tutorial converts the pure Pytorch approach in [Pytorch's Transfer Learning tutorial](https://pytorch.org/tutorials/beginner/transfer_learning_tutorial.html#sphx-glr-beginner-transfer-learning-tutorial-py) into using `skorch`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from functools import partial\n",
+    "\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.optim as optim\n",
+    "import numpy as np\n",
+    "from torchvision import datasets, models, transforms\n",
+    "\n",
+    "from skorch import NeuralNetClassifier\n",
+    "from skorch.callbacks import LRScheduler, Checkpoint\n",
+    "from skorch.helper import filtered_optimizer\n",
+    "from skorch.helper import filter_requires_grad"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The Problem"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Before we begin, download the data from [here](https://download.pytorch.org/tutorial/hymenoptera_data.zip) and extract it to the current directory.\n",
+    "\n",
+    "We are going to train a neutral network to classify **ants** and **bees**. The dataset consist of 120 training images and 75 validiation images for each class. First we create the training and validiation datasets:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_dir = 'hymenoptera_data'\n",
+    "train_transforms = transforms.Compose([\n",
+    "    transforms.RandomResizedCrop(224),\n",
+    "    transforms.RandomHorizontalFlip(),\n",
+    "    transforms.ToTensor(),\n",
+    "    transforms.Normalize([0.485, 0.456, 0.406], \n",
+    "                         [0.229, 0.224, 0.225])\n",
+    "])\n",
+    "val_transforms = transforms.Compose([\n",
+    "    transforms.Resize(256),\n",
+    "    transforms.CenterCrop(224),\n",
+    "    transforms.ToTensor(),\n",
+    "    transforms.Normalize([0.485, 0.456, 0.406], \n",
+    "                         [0.229, 0.224, 0.225])\n",
+    "])\n",
+    "\n",
+    "train_ds = datasets.ImageFolder(\n",
+    "    os.path.join(data_dir, 'train'), train_transforms)\n",
+    "val_ds = datasets.ImageFolder(\n",
+    "    os.path.join(data_dir, 'val'), val_transforms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The train dataset includes data augmentation techniques such as cropping to size 224 and horizontal flips.The train and validiation datasets are normalized with mean: `[0.485, 0.456, 0.406]`, and standard deviation: `[0.229, 0.224, 0.225]`. These values are the means and standard deviations of the ImageNet images. We used these values because the pretrained model was trained on ImageNet."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading pretrained model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use a pretrained `ResNet18` neutral network model with its final layer replaced with a fully connected layer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_ft = models.resnet18(pretrained=True)\n",
+    "num_ftrs = model_ft.fc.in_features\n",
+    "model_ft.fc = nn.Linear(num_ftrs, 2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since we are training a binary classifier, the output of the final fully connected layer has size 2. Next, we freeze all layers except the final layer by setting `require_grad` to False:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name, param in model_ft.named_parameters():\n",
+    "    if not name.startswith('fc'):\n",
+    "        param.requires_grad_(False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using skorch's API"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this section, we will create a `skorch.NeuralNetClassifier` to solve our classification problem. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Callbacks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we create two callbacks:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lrscheduler = LRScheduler(\n",
+    "    policy='StepLR', step_size=7, gamma=0.1)\n",
+    "\n",
+    "checkpoint = Checkpoint(\n",
+    "    target='best_model.pt', monitor='valid_acc_best')\n",
+    "\n",
+    "callbacks = [lrscheduler, checkpoint]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `LRScheduler` callback defines a learning rate scheduler that uses `torch.optim.lr_scheduler.StepLR` to scale learning rates by `gamma=0.1` every 7 steps. The `Checkpoint` callback saves the best model by monitor the validation accuracy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Filtered optimizer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since we froze some layers in our `Resnet18` neutral network, we need to configure our optimizer to only update gradients in our final fully connected layer. Luckily, `skorch` provides two functions that make this simple:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer = filtered_optimizer(\n",
+    "    optim.SGD, filter_requires_grad\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Working with torch.utils.data.Dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have already split our data into training and validation datasets: `train_ds` and `val_ds`. In order for skorch to use these datasets we define a helper function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train_valid_split(train, valid, **kwargs):\n",
+    "    return train, valid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This function just does not do any processing and just returns the two datasets. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### skorch.NeutralNetClassifier"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With all the preparations out of the way, we can now define our `NeutralNetClassifier`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "net = NeuralNetClassifier(\n",
+    "    model_ft, \n",
+    "    criterion=nn.CrossEntropyLoss,\n",
+    "    lr=0.001,\n",
+    "    batch_size=4,\n",
+    "    max_epochs=25,\n",
+    "    optimizer=optimizer,\n",
+    "    optimizer__momentum=0.9,\n",
+    "    iterator_train__shuffle=True,\n",
+    "    iterator_train__num_workers=4,\n",
+    "    iterator_valid__shuffle=True,\n",
+    "    iterator_valid__num_workers=4,\n",
+    "    train_split=train_valid_split,\n",
+    "    callbacks=callbacks,\n",
+    "#     device='cuda' # uncomment to train on gpu\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That is quite a few parameters! Lets walk through each one:\n",
+    "\n",
+    "1. `model_ft`: Our `ResNet18` neutral network\n",
+    "2. `criterion=nn.CrossEntropyLoss`: loss function\n",
+    "3. `lr`: Initial learning rate\n",
+    "4. `batch_size`: Size of a batch\n",
+    "5. `max_epochs`: Number of epochs to train\n",
+    "6. `optimizer`: Our filtered optimizer\n",
+    "7. `optimizer__momentum`: The intial momentum\n",
+    "8. `iterator_{train,valid}__{shuffle,num_workers}`: Parameters that are passed to the dataloader.\n",
+    "9. `train_split`: Our custom `train_valid_split` function\n",
+    "10. `callbacks`: Our callbacks \n",
+    "11. `device`: Set to `cuda` to train on gpu.\n",
+    "\n",
+    "Now we are ready to train our neutral network:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checkpoint! Saving model to best_model.pt.\n",
+      "  epoch    train_loss    valid_acc    valid_loss     dur\n",
+      "-------  ------------  -----------  ------------  ------\n",
+      "      1        \u001b[36m0.3510\u001b[0m       \u001b[32m0.9477\u001b[0m        \u001b[35m0.1671\u001b[0m  1.2843\n",
+      "      2        0.4117       0.9477        0.2174  1.2961\n",
+      "      3        0.3629       0.9412        0.1957  1.3684\n",
+      "      4        0.4517       0.9477        0.2357  1.3041\n",
+      "      5        0.4432       0.9346        0.1920  1.3495\n",
+      "      6        0.4343       0.7974        0.6507  1.2952\n",
+      "      7        0.5948       0.9281        0.1940  1.3564\n",
+      "      8        0.3813       0.9412        \u001b[35m0.1663\u001b[0m  1.3061\n",
+      "      9        \u001b[36m0.2655\u001b[0m       0.9412        0.1742  1.4253\n",
+      "     10        0.2923       0.9412        \u001b[35m0.1584\u001b[0m  1.3351\n",
+      "     11        0.3905       0.9412        0.1710  1.3842\n",
+      "     12        \u001b[36m0.2401\u001b[0m       0.9346        0.1669  1.3937\n",
+      "     13        0.3938       0.9281        0.1752  1.3792\n",
+      "     14        0.3182       0.9346        0.1641  1.3750\n",
+      "     15        0.3410       0.9412        0.1763  1.3427\n",
+      "     16        0.2690       0.9412        0.1607  1.3656\n",
+      "     17        0.3285       0.9346        0.1706  1.3226\n",
+      "     18        0.3467       0.9412        0.1664  1.3304\n",
+      "     19        0.3676       0.9412        0.1695  1.3928\n",
+      "     20        0.3713       0.9346        0.1798  1.3404\n",
+      "     21        0.3314       0.9346        0.1764  1.3611\n",
+      "Checkpoint! Saving model to best_model.pt.\n",
+      "     22        0.3295       \u001b[32m0.9608\u001b[0m        \u001b[35m0.1559\u001b[0m  1.3426\n",
+      "     23        0.3450       0.9412        0.1664  1.2708\n",
+      "     24        0.3228       0.9346        0.1693  1.3055\n",
+      "     25        0.2712       0.9477        0.1588  1.3874\n"
+     ]
+    }
+   ],
+   "source": [
+    "net.fit(train_ds, val_ds);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The best model is stored at `best_model.pt`, with a validiation accuracy of `0.9608`. \n",
+    "\n",
+    "Congrualations! You now know how to finetune a neutral network using `skorch`. Feel free to explore the other tutorials to learn more about using `skorch`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This addresses https://github.com/dnouri/skorch/issues/261 and maybe https://github.com/dnouri/skorch/issues/278.

I covered finetuning and how to use a custom train/valid dataset. I think its pretty common for people coming from the pure `PyTorch` approach to want to provide their own train/validation datasets.

I approached the custom datasets by defining a custom `train_valid` function:

```python
def train_valid_split(train, valid, **kwargs):
    return train, valid

net = NeuralNetClassifier(..., train_split=train_valid_split)
net.fit(train_ds, val_ds);
```

This is a pretty hacky approach to the problem. By defining `train_valid_split ` that just returns its inputs, I treated `X` as the training dataset, and `y` as the validation set.