### PR TITLE
WIP: Adds TrainValidDataset

### DIFF
--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -14,6 +14,7 @@ from skorch.callbacks import BatchScoring
 from skorch.dataset import CVSplit
 from skorch.utils import get_dim
 from skorch.utils import is_dataset
+from skorch.utils import is_train_valid_dataset
 from skorch.utils import noop
 from skorch.utils import to_numpy
 from skorch.utils import train_loss_score
@@ -89,6 +90,7 @@ class NeuralNetClassifier(NeuralNet):
     def check_data(self, X, y):
         if (
                 (y is None) and
+                (not is_train_valid_dataset(X)) and
                 (not is_dataset(X)) and
                 (self.iterator_train is DataLoader)
         ):
@@ -265,7 +267,7 @@ class NeuralNetBinaryClassifier(NeuralNet):
     # pylint: disable=signature-differs
     def check_data(self, X, y):
         super().check_data(X, y)
-        if get_dim(y) != 1:
+        if (not is_train_valid_dataset(X)) and get_dim(y) != 1:
             raise ValueError("The target data should be 1-dimensional.")
 
     # pylint: disable=signature-differs

--- a/skorch/dataset.py
+++ b/skorch/dataset.py
@@ -284,8 +284,9 @@ class CVSplit(object):
 
 
 class TrainValidDataset:
-    """Small wrapper class to support custom training and validation
-    datasets. This class can be passed into ``NeutralNet.fit``,
+    """Small wrapper class to support pre-existing training and
+    validation datasets.
+    This class can be passed into ``NeutralNet.fit``,
     ``NeutralNet.fit_loop``, ``NeutralNet.parital_fit``, or
     ``NeutralNet.get_split_datasets``.
 

--- a/skorch/dataset.py
+++ b/skorch/dataset.py
@@ -281,3 +281,23 @@ class CVSplit(object):
     def __repr__(self):
         # pylint: disable=useless-super-delegation
         return super(CVSplit, self).__repr__()
+
+
+class TrainValidDataset:
+    """Small wrapper class to support custom training and validation
+    datasets. This class can be passed into ``NeutralNet.fit``,
+    ``NeutralNet.fit_loop``, ``NeutralNet.parital_fit``, or
+    ``NeutralNet.get_split_datasets``.
+
+    Parameters
+    ----------
+    train_dataset: Dataset
+        Training dataset
+
+    valid_dataset: Dataset
+        Validation dataset
+
+    """
+    def __init__(self, train_dataset, valid_dataset):
+        self.train_dataset = train_dataset
+        self.valid_dataset = valid_dataset

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -25,6 +25,7 @@ from skorch.history import History
 from skorch.utils import FirstStepAccumulator
 from skorch.utils import duplicate_items
 from skorch.utils import is_dataset
+from skorch.utils import is_train_valid_dataset
 from skorch.utils import noop
 from skorch.utils import open_file_like
 from skorch.utils import params_for
@@ -607,9 +608,13 @@ class NeuralNet(object):
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
+            * a TrainValidDataset
 
           If this doesn't work with your data, you have to pass a
           ``Dataset`` that can deal with the data.
+
+          If you have your own train and validation datasets,
+          ``TrainValidDataset`` can be uesd.
 
         y : target data, compatible with skorch.dataset.Dataset
           The same data types as for ``X`` are supported. If your X is
@@ -683,9 +688,13 @@ class NeuralNet(object):
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
+            * a TrainValidDataset
 
           If this doesn't work with your data, you have to pass a
           ``Dataset`` that can deal with the data.
+
+          If you have your own train and validation datasets,
+          ``TrainValidDataset`` can be uesd.
 
         y : target data, compatible with skorch.dataset.Dataset
           The same data types as for ``X`` are supported. If your X is
@@ -728,9 +737,13 @@ class NeuralNet(object):
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
+            * a TrainValidDataset
 
           If this doesn't work with your data, you have to pass a
           ``Dataset`` that can deal with the data.
+
+          If you have your own train and validation datasets,
+          ``TrainValidDataset`` can be uesd.
 
         y : target data, compatible with skorch.dataset.Dataset
           The same data types as for ``X`` are supported. If your X is
@@ -1030,6 +1043,9 @@ class NeuralNet(object):
         Override this if you want to change how the net splits
         incoming data into train and validation part.
 
+        If ``X`` is a ``TrainValidDataset``, then the corresponding
+        training and validation datasets will be returned.
+
         Parameters
         ----------
         X : input data, compatible with skorch.dataset.Dataset
@@ -1041,6 +1057,7 @@ class NeuralNet(object):
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
+            * a TrainValidDataset
 
           If this doesn't work with your data, you have to pass a
           ``Dataset`` that can deal with the data.
@@ -1063,6 +1080,9 @@ class NeuralNet(object):
           The initialized validation dataset or None
 
         """
+        if is_train_valid_dataset(X):
+            return X.train_dataset, X.valid_dataset
+
         dataset = self.get_dataset(X, y)
         if self.train_split:
             dataset_train, dataset_valid = self.train_split(

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -608,7 +608,7 @@ class NeuralNet(object):
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
-            * a TrainValidDataset
+            * a skorch.dataset.TrainValidDataset
 
           If this doesn't work with your data, you have to pass a
           ``Dataset`` that can deal with the data.
@@ -688,7 +688,7 @@ class NeuralNet(object):
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
-            * a TrainValidDataset
+            * a skorch.dataset.TrainValidDataset
 
           If this doesn't work with your data, you have to pass a
           ``Dataset`` that can deal with the data.
@@ -737,7 +737,7 @@ class NeuralNet(object):
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
-            * a TrainValidDataset
+            * a skorch.dataset.TrainValidDataset
 
           If this doesn't work with your data, you have to pass a
           ``Dataset`` that can deal with the data.
@@ -1057,7 +1057,7 @@ class NeuralNet(object):
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
-            * a TrainValidDataset
+            * a skorch.dataset.TrainValidDataset
 
           If this doesn't work with your data, you have to pass a
           ``Dataset`` that can deal with the data.

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -232,3 +232,15 @@ class TestNeuralNetBinaryClassifier:
 
         net.predict_proba(X)
         assert mock.call_count > 0
+
+    def test_train_valid_dataset(self, net_cls, module_cls, data):
+        from skorch.dataset import TrainValidDataset
+        from skorch.dataset import Dataset
+
+        train_ds = Dataset(*data)
+        valid_ds = Dataset(*data)
+
+        net = net_cls(module_cls, max_epochs=1)
+
+        train_valid_ds = TrainValidDataset(train_ds, valid_ds)
+        net.fit(train_valid_ds, None)  # Does not raise

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1444,3 +1444,14 @@ class TestNeuralNet:
         expected_losses = list(
             flatten(net.history[:, 'batches', :, 'train_loss']))
         assert np.allclose(side_effect[2::3], expected_losses)
+
+    def test_train_valid_dataset(self, net_cls, module_cls, data, dataset_cls):
+        from skorch.dataset import TrainValidDataset
+
+        train_ds = dataset_cls(*data)
+        valid_ds = dataset_cls(*data)
+
+        net = net_cls(module_cls, max_epochs=1)
+
+        train_valid_ds = TrainValidDataset(train_ds, valid_ds)
+        net.fit(train_valid_ds, None)  # Does not raise

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1451,7 +1451,21 @@ class TestNeuralNet:
         train_ds = dataset_cls(*data)
         valid_ds = dataset_cls(*data)
 
-        net = net_cls(module_cls, max_epochs=1)
+        train_loader_mock = Mock(side_effect=torch.utils.data.DataLoader)
+        valid_loader_mock = Mock(side_effect=torch.utils.data.DataLoader)
+
+        net = net_cls(
+            module_cls,
+            max_epochs=1,
+            iterator_train=train_loader_mock,
+            iterator_valid=valid_loader_mock,
+        )
 
         train_valid_ds = TrainValidDataset(train_ds, valid_ds)
         net.fit(train_valid_ds, None)  # Does not raise
+
+        train_dataset = train_loader_mock.call_args[0][0]
+        valid_dataset = valid_loader_mock.call_args[0][0]
+
+        assert train_dataset == train_ds
+        assert valid_dataset == valid_ds

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -417,3 +417,44 @@ class TestIsSkorchDataset:
         type_truth_table())
     def test_data_types(self, is_skorch_dataset, input_data, expected):
         assert is_skorch_dataset(input_data) == expected
+
+
+class TestIsTrainValidDataset:
+
+    @pytest.fixture
+    def is_train_valid_dataset(self):
+        from skorch.utils import is_train_valid_dataset
+        return is_train_valid_dataset
+
+    # pylint: disable=no-method-argument
+    def type_truth_table():
+        """Return a table of (type, bool) tuples that describe what
+        is_train_valid_dataset should return when called with that type.
+        """
+        from skorch.dataset import Dataset
+        from skorch.dataset import TrainValidDataset
+        from torch.utils.data.dataset import Subset
+
+        numpy_data = np.array([1, 2, 3])
+        tensor_data = torch.from_numpy(numpy_data)
+        torch_dataset = torch.utils.data.TensorDataset(
+            tensor_data, tensor_data)
+        torch_subset = Subset(torch_dataset, [1, 2])
+        skorch_dataset = Dataset(numpy_data)
+        skorch_subset = Subset(skorch_dataset, [1, 2])
+        train_valid_ds = TrainValidDataset(skorch_dataset, skorch_subset)
+
+        return [
+            (numpy_data, False),
+            (torch_dataset, False),
+            (torch_subset, False),
+            (skorch_dataset, False),
+            (skorch_subset, False),
+            (train_valid_ds, True)
+        ]
+
+    @pytest.mark.parametrize(
+        'input_data,expected',
+        type_truth_table())
+    def test_data_types(self, is_train_valid_dataset, input_data, expected):
+        assert is_train_valid_dataset(input_data) == expected

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -357,6 +357,13 @@ def is_skorch_dataset(ds):
     return isinstance(ds, Dataset)
 
 
+def is_train_valid_dataset(ds):
+    """Checks if the supplied dataset is an instance of
+    ``skorch.dataset.TrainValidDataset``."""
+    from skorch.dataset import TrainValidDataset
+    return isinstance(ds, TrainValidDataset)
+
+
 # pylint: disable=unused-argument
 def noop(*args, **kwargs):
     """No-op function that does nothing and returns ``None``.


### PR DESCRIPTION
This is PR will be updated based on the discussions in #282.

Currently, `TrainValidDataset` is a namedtuple containing a training and validation dataset. When `get_split_datasets` is called, it first checks for this namedtuple, and returns the corresponding training and validation datasets.