### PR TITLE
RFC: Converts make_optimizer to a private func

### DIFF
--- a/skorch/helper.py
+++ b/skorch/helper.py
@@ -5,6 +5,7 @@ They should not be used in skorch directly.
 """
 from functools import partial
 from skorch.utils import _make_split
+from skorch.utils import _make_optimizer
 
 
 class SliceDict(dict):
@@ -112,8 +113,7 @@ def filtered_optimizer(optimizer, filter_fn):
       it to ``optimizer``.
 
     """
-    from skorch.utils import make_optimizer
-    return partial(make_optimizer, optimizer=optimizer, filter_fn=filter_fn)
+    return partial(_make_optimizer, optimizer=optimizer, filter_fn=filter_fn)
 
 
 def predefined_split(dataset):

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -417,7 +417,7 @@ class FirstStepAccumulator:
         return self.step
 
 
-def make_optimizer(pgroups, optimizer, filter_fn, **kwargs):
+def _make_optimizer(pgroups, optimizer, filter_fn, **kwargs):
     """Used by ``skorch.helper.filtered_optimizer`` to allow for pickling"""
     return optimizer(filter_fn(pgroups), **kwargs)
 


### PR DESCRIPTION
Adapts the style of `skorch.utils._make_split` by converting `skorch.utils.make_optimizer` to a private function.