### PR TITLE
Support saving params, history, and pickling in Checkpoint

### DIFF
--- a/docs/user/callbacks.rst
+++ b/docs/user/callbacks.rst
@@ -179,25 +179,30 @@ Checkpoint
 ----------
 
 The :class:`.Checkpoint` callback creates a checkpoint of your model
-parameters after each epoch if your validation loss improved.
-
-To change where your model is saved, change the ``target``
-argument. To change under what circumstances your model is saved,
-change the ``monitor`` argument. The latter can take 3 types of
+after each epoch that met certain criteria. By default, the condition
+is that the validation loss has improved, however you may change this
+by specifying the ``monitor`` parameter. It can take three types of
 arguments:
 
-- ``None``: The model is saved after each epoch
+- ``None``: The model is saved after each epoch;
 - string: The model checks whether the last entry in the model
   ``history`` for that key is truthy. This is useful in conjunction
   with scores determined by a scoring callback. They write a
   ``<score>_best`` entry to the ``history``, which can be used for
   checkpointing. By default, the :class:`.Checkpoint` callback looks
-  at ``'valid_loss_best'``.
+  at ``'valid_loss_best'``;
 - function or callable: In that case, the function should take the
   :class:`.NeuralNet` instance as sole input and return a bool as
   output.
 
-The model parameters are saved using
-:func:`~skorch.net.NeuralNet.save_params`. Please refer to
-:ref:`saving and loading` for more information about restoring your
-network from a checkpoint.
+To specify where and how your model is saved, change the arguments
+starting with ``f_``:
+
+- ``f_params``: to save model parameters (uses
+  :func:`~skorch.net.NeuralNet.save_params`);
+- ``f_history``: to save training history (uses
+  :func:`~skorch.net.NeuralNet.save_history`);
+- ``f_pickle``: to pickle the entire model object.
+
+Please refer to :ref:`saving and loading` for more information about
+restoring your network from a checkpoint.

--- a/notebooks/Transfer_Learning.ipynb
+++ b/notebooks/Transfer_Learning.ipynb
@@ -220,7 +220,7 @@
     "    policy='StepLR', step_size=7, gamma=0.1)\n",
     "\n",
     "checkpoint = Checkpoint(\n",
-    "    target='best_model.pt', monitor='valid_acc_best')\n",
+    "    f_params='best_model.pt', monitor='valid_acc_best')\n",
     "\n",
     "callbacks = [lrscheduler, checkpoint]"
    ]


### PR DESCRIPTION
This PR is a work in progress to add the features discussed in #289. I would like to get feedback before updating unit tests and documentation.

Some notes/discussion points:
 * I dropped sink output for a bunch of reasons:
   * Too verbose if all three targets are used
   * Meaningless if target is a file-like object
   * Would unnecessary complicate `save_model()`
   * Now that we have events in the log I don't see much value in having it anyway
 * This change may break existing code that did not explicitly specify argument names in constructor call. For example, `Checkpoint('model.pt', 'train_loss_best')` will now behave differently. Not sure how to deal with this other than introducing [keyword-only arguments](https://www.python.org/dev/peps/pep-3102/).