### PR TITLE
WIP: Update to 0.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ install:
   - source activate skorch-env
   - conda install --file=requirements-dev.txt
   - python setup.py install
-  - conda install -c pytorch 'pytorch-cpu>=0.4.0'
+  - conda install -c pytorch 'pytorch-cpu>=0.4.1'
 script:
   - pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-cudnn7-devel
+FROM nvidia/cuda:9.0-cudnn7-runtime
 
 RUN apt-get update && \
 	apt-get install -y python3.5-dev vim git g++ sudo zip python3-setuptools
@@ -6,7 +6,7 @@ RUN easy_install3 --upgrade pip setuptools
 
 ENV PIP_CACHE_DIR=/cache PYTHONDONTWRITEBYTECODE=1
 
-RUN pip3 install http://download.pytorch.org/whl/cu90/torch-0.4.0-cp35-cp35m-linux_x86_64.whl
+RUN pip3 install torch
 RUN pip3 install torchvision
 
 WORKDIR /app

--- a/README.rst
+++ b/README.rst
@@ -212,7 +212,7 @@ In general, this should work (assuming CUDA 9):
     # using conda:
     conda install pytorch cuda90 -c pytorch
     # using pip
-    pip install http://download.pytorch.org/whl/cu90/torch-0.4.0-cp36-cp36m-linux_x86_64.whl
+    pip install torch
 
 =============
 Communication

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.13.3
-http://download.pytorch.org/whl/cpu/torch-0.4.0-cp35-cp35m-linux_x86_64.whl
+torch==0.4.1
 sphinx-rtd-theme==0.4.0
 numpydoc==0.8.0

--- a/notebooks/Advanced_Usage.ipynb
+++ b/notebooks/Advanced_Usage.ipynb
@@ -137,7 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from skorch.net import NeuralNetClassifier"
+    "from skorch import NeuralNetClassifier"
    ]
   },
   {
@@ -287,16 +287,16 @@
      "text": [
       "  epoch    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ------------  -----------  ------------  ------\n",
-      "      1        \u001b[36m0.6908\u001b[0m       \u001b[32m0.5950\u001b[0m        \u001b[35m0.6842\u001b[0m  0.0315\n",
-      "      2        \u001b[36m0.6876\u001b[0m       0.5950        \u001b[35m0.6815\u001b[0m  0.0256\n",
-      "      3        \u001b[36m0.6853\u001b[0m       \u001b[32m0.6100\u001b[0m        \u001b[35m0.6789\u001b[0m  0.0365\n",
-      "      4        0.6882       0.5950        \u001b[35m0.6769\u001b[0m  0.0290\n",
-      "      5        \u001b[36m0.6780\u001b[0m       0.6000        \u001b[35m0.6743\u001b[0m  0.0230\n",
-      "      6        \u001b[36m0.6730\u001b[0m       0.6100        \u001b[35m0.6717\u001b[0m  0.0238\n",
-      "      7        \u001b[36m0.6664\u001b[0m       \u001b[32m0.6150\u001b[0m        \u001b[35m0.6698\u001b[0m  0.0232\n",
-      "      8        0.6670       0.6100        \u001b[35m0.6670\u001b[0m  0.0234\n",
-      "      9        0.6667       \u001b[32m0.6300\u001b[0m        \u001b[35m0.6646\u001b[0m  0.0342\n",
-      "     10        \u001b[36m0.6624\u001b[0m       \u001b[32m0.6350\u001b[0m        \u001b[35m0.6624\u001b[0m  0.0234\n",
+      "      1        \u001b[36m0.6954\u001b[0m       \u001b[32m0.6000\u001b[0m        \u001b[35m0.6844\u001b[0m  0.0158\n",
+      "      2        \u001b[36m0.6802\u001b[0m       0.5950        \u001b[35m0.6817\u001b[0m  0.0091\n",
+      "      3        0.6839       0.6000        \u001b[35m0.6792\u001b[0m  0.0090\n",
+      "      4        \u001b[36m0.6753\u001b[0m       0.5900        \u001b[35m0.6767\u001b[0m  0.0087\n",
+      "      5        0.6769       0.5950        \u001b[35m0.6742\u001b[0m  0.0086\n",
+      "      6        0.6774       \u001b[32m0.6050\u001b[0m        \u001b[35m0.6720\u001b[0m  0.0091\n",
+      "      7        \u001b[36m0.6693\u001b[0m       \u001b[32m0.6250\u001b[0m        \u001b[35m0.6695\u001b[0m  0.0089\n",
+      "      8        0.6694       \u001b[32m0.6300\u001b[0m        \u001b[35m0.6672\u001b[0m  0.0090\n",
+      "      9        0.6703       \u001b[32m0.6400\u001b[0m        \u001b[35m0.6652\u001b[0m  0.0088\n",
+      "     10        \u001b[36m0.6523\u001b[0m       \u001b[32m0.6550\u001b[0m        \u001b[35m0.6623\u001b[0m  0.0088\n",
       "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
       "*tweet* Accuracy never reached 0.7 :( #skorch #pytorch\n",
       "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
@@ -305,7 +305,7 @@
     {
      "data": {
       "text/plain": [
-       "<class 'skorch.net.NeuralNetClassifier'>[initialized](\n",
+       "<class 'skorch.classifier.NeuralNetClassifier'>[initialized](\n",
        "  module_=ClassifierModule(\n",
        "    (dense0): Linear(in_features=20, out_features=10, bias=True)\n",
        "    (dropout): Dropout(p=0.5)\n",
@@ -340,25 +340,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     11        0.6647       \u001b[32m0.6500\u001b[0m        \u001b[35m0.6598\u001b[0m  0.0240\n",
-      "     12        \u001b[36m0.6573\u001b[0m       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6575\u001b[0m  0.0240\n",
-      "     13        \u001b[36m0.6458\u001b[0m       \u001b[32m0.6700\u001b[0m        \u001b[35m0.6549\u001b[0m  0.0250\n",
-      "     14        0.6528       \u001b[32m0.6750\u001b[0m        \u001b[35m0.6525\u001b[0m  0.0242\n",
-      "     15        0.6476       0.6700        \u001b[35m0.6502\u001b[0m  0.0240\n",
-      "     16        0.6483       0.6750        \u001b[35m0.6476\u001b[0m  0.0244\n",
-      "     17        0.6514       \u001b[32m0.6800\u001b[0m        \u001b[35m0.6452\u001b[0m  0.0254\n",
-      "     18        \u001b[36m0.6365\u001b[0m       \u001b[32m0.6850\u001b[0m        \u001b[35m0.6422\u001b[0m  0.0231\n",
-      "     19        \u001b[36m0.6335\u001b[0m       \u001b[32m0.7000\u001b[0m        \u001b[35m0.6390\u001b[0m  0.0230\n",
-      "     20        0.6381       \u001b[32m0.7100\u001b[0m        \u001b[35m0.6363\u001b[0m  0.0233\n",
+      "     11        0.6641       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6603\u001b[0m  0.0088\n",
+      "     12        0.6524       0.6650        \u001b[35m0.6582\u001b[0m  0.0090\n",
+      "     13        \u001b[36m0.6506\u001b[0m       \u001b[32m0.6700\u001b[0m        \u001b[35m0.6553\u001b[0m  0.0089\n",
+      "     14        \u001b[36m0.6489\u001b[0m       0.6650        \u001b[35m0.6527\u001b[0m  0.0089\n",
+      "     15        0.6505       \u001b[32m0.6750\u001b[0m        \u001b[35m0.6502\u001b[0m  0.0089\n",
+      "     16        \u001b[36m0.6473\u001b[0m       0.6750        \u001b[35m0.6474\u001b[0m  0.0089\n",
+      "     17        \u001b[36m0.6431\u001b[0m       \u001b[32m0.6800\u001b[0m        \u001b[35m0.6443\u001b[0m  0.0087\n",
+      "     18        0.6461       \u001b[32m0.6900\u001b[0m        \u001b[35m0.6418\u001b[0m  0.0087\n",
+      "     19        \u001b[36m0.6430\u001b[0m       0.6850        \u001b[35m0.6392\u001b[0m  0.0086\n",
+      "     20        \u001b[36m0.6364\u001b[0m       \u001b[32m0.6950\u001b[0m        \u001b[35m0.6366\u001b[0m  0.0088\n",
       "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
-      "*tweet* Accuracy reached 0.7 at epoch 19!!! #skorch #pytorch\n",
+      "*tweet* Accuracy never reached 0.7 :( #skorch #pytorch\n",
       "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<class 'skorch.net.NeuralNetClassifier'>[initialized](\n",
+       "<class 'skorch.classifier.NeuralNetClassifier'>[initialized](\n",
        "  module_=ClassifierModule(\n",
        "    (dense0): Linear(in_features=20, out_features=10, bias=True)\n",
        "    (dropout): Dropout(p=0.5)\n",
@@ -459,25 +459,25 @@
      "text": [
       "  epoch    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ------------  -----------  ------------  ------\n",
-      "      1        \u001b[36m0.7139\u001b[0m       \u001b[32m0.5500\u001b[0m        \u001b[35m0.6933\u001b[0m  0.0317\n",
-      "      2        \u001b[36m0.6916\u001b[0m       \u001b[32m0.5950\u001b[0m        \u001b[35m0.6873\u001b[0m  0.0283\n",
-      "      3        \u001b[36m0.6829\u001b[0m       0.5800        \u001b[35m0.6814\u001b[0m  0.0212\n",
-      "      4        \u001b[36m0.6671\u001b[0m       \u001b[32m0.6050\u001b[0m        \u001b[35m0.6718\u001b[0m  0.0228\n",
-      "      5        \u001b[36m0.6670\u001b[0m       \u001b[32m0.6200\u001b[0m        \u001b[35m0.6639\u001b[0m  0.0229\n",
-      "      6        \u001b[36m0.6622\u001b[0m       \u001b[32m0.6350\u001b[0m        \u001b[35m0.6546\u001b[0m  0.0236\n",
-      "      7        \u001b[36m0.6371\u001b[0m       \u001b[32m0.6550\u001b[0m        \u001b[35m0.6429\u001b[0m  0.0240\n",
-      "      8        \u001b[36m0.6293\u001b[0m       \u001b[32m0.6700\u001b[0m        \u001b[35m0.6312\u001b[0m  0.0236\n",
-      "      9        \u001b[36m0.6170\u001b[0m       0.6650        \u001b[35m0.6200\u001b[0m  0.0240\n",
-      "     10        0.6204       \u001b[32m0.6750\u001b[0m        \u001b[35m0.6119\u001b[0m  0.0255\n",
+      "      1        \u001b[36m0.7114\u001b[0m       \u001b[32m0.5150\u001b[0m        \u001b[35m0.6923\u001b[0m  0.0089\n",
+      "      2        \u001b[36m0.6959\u001b[0m       \u001b[32m0.5300\u001b[0m        \u001b[35m0.6831\u001b[0m  0.0090\n",
+      "      3        \u001b[36m0.6856\u001b[0m       \u001b[32m0.6000\u001b[0m        \u001b[35m0.6752\u001b[0m  0.0088\n",
+      "      4        \u001b[36m0.6768\u001b[0m       \u001b[32m0.6300\u001b[0m        \u001b[35m0.6686\u001b[0m  0.0091\n",
+      "      5        \u001b[36m0.6670\u001b[0m       \u001b[32m0.6500\u001b[0m        \u001b[35m0.6585\u001b[0m  0.0088\n",
+      "      6        \u001b[36m0.6607\u001b[0m       0.6300        \u001b[35m0.6496\u001b[0m  0.0090\n",
+      "      7        \u001b[36m0.6375\u001b[0m       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6377\u001b[0m  0.0088\n",
+      "      8        \u001b[36m0.6333\u001b[0m       \u001b[32m0.6800\u001b[0m        \u001b[35m0.6263\u001b[0m  0.0089\n",
+      "      9        \u001b[36m0.6160\u001b[0m       \u001b[32m0.6850\u001b[0m        \u001b[35m0.6117\u001b[0m  0.0089\n",
+      "     10        \u001b[36m0.6109\u001b[0m       0.6850        \u001b[35m0.5983\u001b[0m  0.0088\n",
       "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
-      "*tweet* Accuracy reached 0.6 at epoch 4!!! #skorch #pytorch\n",
+      "*tweet* Accuracy reached 0.6 at epoch 3!!! #skorch #pytorch\n",
       "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<class 'skorch.net.NeuralNetClassifier'>[initialized](\n",
+       "<class 'skorch.classifier.NeuralNetClassifier'>[initialized](\n",
        "  module_=ClassifierModule(\n",
        "    (dense0): Linear(in_features=20, out_features=10, bias=True)\n",
        "    (dropout): Dropout(p=0.5)\n",
@@ -511,7 +511,7 @@
     {
      "data": {
       "text/plain": [
-       "<class 'skorch.net.NeuralNetClassifier'>[initialized](\n",
+       "<class 'skorch.classifier.NeuralNetClassifier'>[initialized](\n",
        "  module_=ClassifierModule(\n",
        "    (dense0): Linear(in_features=20, out_features=10, bias=True)\n",
        "    (dropout): Dropout(p=0.5)\n",
@@ -541,25 +541,25 @@
      "text": [
       "  epoch    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ------------  -----------  ------------  ------\n",
-      "     11        \u001b[36m0.5845\u001b[0m       \u001b[32m0.7000\u001b[0m        \u001b[35m0.6016\u001b[0m  0.0237\n",
-      "     12        \u001b[36m0.5831\u001b[0m       \u001b[32m0.7050\u001b[0m        \u001b[35m0.5915\u001b[0m  0.0221\n",
-      "     13        0.5854       \u001b[32m0.7200\u001b[0m        \u001b[35m0.5788\u001b[0m  0.0221\n",
-      "     14        \u001b[36m0.5582\u001b[0m       0.7150        \u001b[35m0.5729\u001b[0m  0.0226\n",
-      "     15        0.5601       0.7150        \u001b[35m0.5692\u001b[0m  0.0247\n",
-      "     16        \u001b[36m0.5468\u001b[0m       \u001b[32m0.7250\u001b[0m        \u001b[35m0.5662\u001b[0m  0.0222\n",
-      "     17        \u001b[36m0.5333\u001b[0m       \u001b[32m0.7300\u001b[0m        \u001b[35m0.5583\u001b[0m  0.0230\n",
-      "     18        0.5592       0.7200        \u001b[35m0.5555\u001b[0m  0.0240\n",
-      "     19        \u001b[36m0.5295\u001b[0m       0.7300        \u001b[35m0.5488\u001b[0m  0.0238\n",
-      "     20        \u001b[36m0.5232\u001b[0m       0.7300        \u001b[35m0.5428\u001b[0m  0.0239\n",
+      "     11        \u001b[36m0.5926\u001b[0m       \u001b[32m0.6900\u001b[0m        \u001b[35m0.5844\u001b[0m  0.0092\n",
+      "     12        \u001b[36m0.5778\u001b[0m       \u001b[32m0.7000\u001b[0m        \u001b[35m0.5719\u001b[0m  0.0092\n",
+      "     13        0.5824       \u001b[32m0.7300\u001b[0m        \u001b[35m0.5597\u001b[0m  0.0088\n",
+      "     14        \u001b[36m0.5639\u001b[0m       \u001b[32m0.7350\u001b[0m        \u001b[35m0.5541\u001b[0m  0.0090\n",
+      "     15        \u001b[36m0.5580\u001b[0m       \u001b[32m0.7400\u001b[0m        \u001b[35m0.5451\u001b[0m  0.0089\n",
+      "     16        \u001b[36m0.5415\u001b[0m       \u001b[32m0.7500\u001b[0m        \u001b[35m0.5334\u001b[0m  0.0087\n",
+      "     17        0.5508       \u001b[32m0.7550\u001b[0m        \u001b[35m0.5333\u001b[0m  0.0087\n",
+      "     18        \u001b[36m0.5317\u001b[0m       0.7400        0.5338  0.0087\n",
+      "     19        \u001b[36m0.5209\u001b[0m       0.7400        \u001b[35m0.5225\u001b[0m  0.0088\n",
+      "     20        0.5275       0.7350        0.5227  0.0087\n",
       "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
-      "*tweet* Accuracy never reached 0.75 :( #skorch #pytorch\n",
+      "*tweet* Accuracy reached 0.75 at epoch 16!!! #skorch #pytorch\n",
       "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<class 'skorch.net.NeuralNetClassifier'>[initialized](\n",
+       "<class 'skorch.classifier.NeuralNetClassifier'>[initialized](\n",
        "  module_=ClassifierModule(\n",
        "    (dense0): Linear(in_features=20, out_features=10, bias=True)\n",
        "    (dropout): Dropout(p=0.5)\n",
@@ -711,22 +711,22 @@
       "Re-initializing module!\n",
       "  epoch    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ------------  -----------  ------------  ------\n",
-      "      1        \u001b[36m0.7097\u001b[0m       \u001b[32m0.5400\u001b[0m        \u001b[35m0.6932\u001b[0m  0.0099\n",
-      "      2        \u001b[36m0.7087\u001b[0m       \u001b[32m0.5500\u001b[0m        \u001b[35m0.6913\u001b[0m  0.0088\n",
-      "      3        0.7182       \u001b[32m0.5550\u001b[0m        \u001b[35m0.6895\u001b[0m  0.0088\n",
-      "      4        0.7088       0.5550        \u001b[35m0.6881\u001b[0m  0.0144\n",
-      "      5        0.7097       0.5550        \u001b[35m0.6867\u001b[0m  0.0089\n",
-      "      6        \u001b[36m0.6943\u001b[0m       0.5550        \u001b[35m0.6854\u001b[0m  0.0085\n",
-      "      7        0.6965       \u001b[32m0.5700\u001b[0m        \u001b[35m0.6842\u001b[0m  0.0090\n",
-      "      8        0.6975       \u001b[32m0.5750\u001b[0m        \u001b[35m0.6830\u001b[0m  0.0087\n",
-      "      9        \u001b[36m0.6896\u001b[0m       \u001b[32m0.5950\u001b[0m        \u001b[35m0.6819\u001b[0m  0.0084\n",
-      "     10        0.6950       \u001b[32m0.6000\u001b[0m        \u001b[35m0.6809\u001b[0m  0.0095\n"
+      "      1        \u001b[36m0.7869\u001b[0m       \u001b[32m0.5000\u001b[0m        \u001b[35m0.7649\u001b[0m  0.0077\n",
+      "      2        \u001b[36m0.7700\u001b[0m       0.5000        \u001b[35m0.7526\u001b[0m  0.0077\n",
+      "      3        \u001b[36m0.7594\u001b[0m       0.5000        \u001b[35m0.7424\u001b[0m  0.0074\n",
+      "      4        \u001b[36m0.7443\u001b[0m       0.5000        \u001b[35m0.7336\u001b[0m  0.0075\n",
+      "      5        \u001b[36m0.7388\u001b[0m       0.5000        \u001b[35m0.7261\u001b[0m  0.0075\n",
+      "      6        \u001b[36m0.7265\u001b[0m       0.5000        \u001b[35m0.7201\u001b[0m  0.0074\n",
+      "      7        \u001b[36m0.7229\u001b[0m       0.5000        \u001b[35m0.7148\u001b[0m  0.0075\n",
+      "      8        \u001b[36m0.7103\u001b[0m       0.5000        \u001b[35m0.7105\u001b[0m  0.0074\n",
+      "      9        \u001b[36m0.7095\u001b[0m       0.5000        \u001b[35m0.7067\u001b[0m  0.0074\n",
+      "     10        \u001b[36m0.7053\u001b[0m       0.5000        \u001b[35m0.7035\u001b[0m  0.0073\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<class 'skorch.net.NeuralNetClassifier'>[initialized](\n",
+       "<class 'skorch.classifier.NeuralNetClassifier'>[initialized](\n",
        "  module_=ClassifierModule(\n",
        "    (dense0): Linear(in_features=20, out_features=10, bias=True)\n",
        "    (dropout): Dropout(p=0.5)\n",
@@ -848,7 +848,7 @@
     {
      "data": {
       "text/plain": [
-       "<class 'skorch.net.NeuralNetClassifier'>[initialized](\n",
+       "<class 'skorch.classifier.NeuralNetClassifier'>[initialized](\n",
        "  module_=ClassifierWithDict(\n",
        "    (dense0): Linear(in_features=10, out_features=50, bias=True)\n",
        "    (dense1): Linear(in_features=10, out_features=50, bias=True)\n",
@@ -919,9 +919,9 @@
        "Pipeline(memory=None,\n",
        "     steps=[('do-nothing', FunctionTransformer(accept_sparse=False, func=None, inv_kw_args=None,\n",
        "          inverse_func=None, kw_args=None, pass_y='deprecated',\n",
-       "          validate=False)), ('net', <class 'skorch.net.NeuralNetClassifier'>[initialized](\n",
+       "          validate=False)), ('net', <class 'skorch.classifier.NeuralNetClassifier'>[initialized](\n",
        "  module_=ClassifierWithDict(\n",
-       "    (dense0): Linear(in... (dropout): Dropout(p=0.5)\n",
+       "    (dense0): Li... (dropout): Dropout(p=0.5)\n",
        "    (output): Linear(in_features=100, out_features=2, bias=True)\n",
        "  ),\n",
        "))])"
@@ -1047,13 +1047,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Slicing the SliceDict slices across values: SliceDict(**{'X0': array([[-0.96583462, -2.18907046,  0.16985609,  0.81384557, -3.37520909,\n",
-      "        -2.14305973, -0.39585084,  2.94195771, -2.19106054,  1.24439669],\n",
-      "       [-0.45476699,  4.33976793, -0.48572844, -4.8843298 , -2.8836503 ,\n",
-      "         2.60972047, -1.95287597, -0.09192174,  0.07970932, -0.08938338]], dtype=float32), 'X1': array([[ 0.04351204, -0.51509613, -0.86073655, -1.10971689,  0.31839254,\n",
-      "        -0.82319731, -1.05630398, -0.89645284,  0.37592441, -1.08496511],\n",
-      "       [-0.60726726, -1.06743085,  0.48804346, -0.50230557,  0.55743027,\n",
-      "         1.01592004, -1.99535823,  2.90304255, -0.97392982,  2.17533231]], dtype=float32)})\n"
+      "Slicing the SliceDict slices across values: SliceDict(**{'X0': array([[-0.9658346 , -2.1890705 ,  0.16985609,  0.8138456 , -3.375209  ,\n",
+      "        -2.1430597 , -0.39585084,  2.9419577 , -2.1910605 ,  1.2443967 ],\n",
+      "       [-0.454767  ,  4.339768  , -0.48572844, -4.88433   , -2.8836503 ,\n",
+      "         2.6097205 , -1.952876  , -0.09192174,  0.07970932, -0.08938338]],\n",
+      "      dtype=float32), 'X1': array([[ 0.04351204, -0.5150961 , -0.86073655, -1.1097169 ,  0.31839254,\n",
+      "        -0.8231973 , -1.056304  , -0.89645284,  0.3759244 , -1.0849651 ],\n",
+      "       [-0.60726726, -1.0674309 ,  0.48804346, -0.50230557,  0.55743027,\n",
+      "         1.01592   , -1.9953582 ,  2.9030426 , -0.9739298 ,  2.1753323 ]],\n",
+      "      dtype=float32)})\n"
      ]
     }
    ],
@@ -1084,7 +1086,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[Parallel(n_jobs=1)]: Done  54 out of  54 | elapsed:   15.6s finished\n"
+      "[Parallel(n_jobs=1)]: Done  54 out of  54 | elapsed:    6.9s finished\n"
      ]
     },
     {
@@ -1094,9 +1096,9 @@
        "       estimator=Pipeline(memory=None,\n",
        "     steps=[('do-nothing', FunctionTransformer(accept_sparse=False, func=None, inv_kw_args=None,\n",
        "          inverse_func=None, kw_args=None, pass_y='deprecated',\n",
-       "          validate=False)), ('net', <class 'skorch.net.NeuralNetClassifier'>[initialized](\n",
+       "          validate=False)), ('net', <class 'skorch.classifier.NeuralNetClassifier'>[initialized](\n",
        "  module_=ClassifierWithDict(\n",
-       "    (dense0): Linear(in... (dropout): Dropout(p=0.5)\n",
+       "    (dense0): Li... (dropout): Dropout(p=0.5)\n",
        "    (output): Linear(in_features=100, out_features=2, bias=True)\n",
        "  ),\n",
        "))]),\n",
@@ -1123,10 +1125,10 @@
     {
      "data": {
       "text/plain": [
-       "(0.76400000000000001,\n",
+       "(0.756,\n",
        " {'net__lr': 0.1,\n",
        "  'net__module__num_units0': 50,\n",
-       "  'net__module__num_units1': 50})"
+       "  'net__module__num_units1': 25})"
       ]
      },
      "execution_count": 37,
@@ -1155,7 +1157,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/Basic_Usage.ipynb
+++ b/notebooks/Basic_Usage.ipynb
@@ -204,7 +204,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from skorch.net import NeuralNetClassifier"
+    "from skorch import NeuralNetClassifier"
    ]
   },
   {
@@ -217,7 +217,7 @@
     "    ClassifierModule,\n",
     "    max_epochs=20,\n",
     "    lr=0.1,\n",
-    "    # device='cuda',  # uncomment this to train with CUDA\n",
+    "#     device='cuda',  # uncomment this to train with CUDA\n",
     ")"
    ]
   },
@@ -258,32 +258,32 @@
      "text": [
       "  epoch    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ------------  -----------  ------------  ------\n",
-      "      1        \u001b[36m0.6868\u001b[0m       \u001b[32m0.6000\u001b[0m        \u001b[35m0.6740\u001b[0m  0.0861\n",
-      "      2        \u001b[36m0.6706\u001b[0m       \u001b[32m0.6400\u001b[0m        \u001b[35m0.6617\u001b[0m  0.0365\n",
-      "      3        \u001b[36m0.6637\u001b[0m       \u001b[32m0.6650\u001b[0m        \u001b[35m0.6504\u001b[0m  0.0418\n",
-      "      4        \u001b[36m0.6548\u001b[0m       \u001b[32m0.7000\u001b[0m        \u001b[35m0.6418\u001b[0m  0.0460\n",
-      "      5        \u001b[36m0.6340\u001b[0m       \u001b[32m0.7100\u001b[0m        \u001b[35m0.6272\u001b[0m  0.0393\n",
-      "      6        \u001b[36m0.6219\u001b[0m       \u001b[32m0.7150\u001b[0m        \u001b[35m0.6124\u001b[0m  0.0387\n",
-      "      7        \u001b[36m0.6058\u001b[0m       0.7100        \u001b[35m0.5980\u001b[0m  0.0407\n",
-      "      8        \u001b[36m0.5964\u001b[0m       \u001b[32m0.7200\u001b[0m        \u001b[35m0.5875\u001b[0m  0.0407\n",
-      "      9        \u001b[36m0.5901\u001b[0m       0.7100        \u001b[35m0.5760\u001b[0m  0.0380\n",
-      "     10        \u001b[36m0.5716\u001b[0m       \u001b[32m0.7250\u001b[0m        \u001b[35m0.5651\u001b[0m  0.0378\n",
-      "     11        \u001b[36m0.5633\u001b[0m       0.7250        \u001b[35m0.5580\u001b[0m  0.0387\n",
-      "     12        0.5652       \u001b[32m0.7300\u001b[0m        \u001b[35m0.5529\u001b[0m  0.0387\n",
-      "     13        \u001b[36m0.5462\u001b[0m       \u001b[32m0.7350\u001b[0m        \u001b[35m0.5426\u001b[0m  0.0397\n",
-      "     14        \u001b[36m0.5407\u001b[0m       0.7300        \u001b[35m0.5407\u001b[0m  0.0395\n",
-      "     15        \u001b[36m0.5360\u001b[0m       0.7300        \u001b[35m0.5373\u001b[0m  0.0373\n",
-      "     16        0.5517       \u001b[32m0.7400\u001b[0m        \u001b[35m0.5328\u001b[0m  0.0372\n",
-      "     17        \u001b[36m0.5351\u001b[0m       \u001b[32m0.7450\u001b[0m        \u001b[35m0.5277\u001b[0m  0.0380\n",
-      "     18        \u001b[36m0.5280\u001b[0m       0.7400        \u001b[35m0.5260\u001b[0m  0.0410\n",
-      "     19        \u001b[36m0.5148\u001b[0m       0.7450        0.5264  0.0388\n",
-      "     20        0.5309       0.7400        \u001b[35m0.5210\u001b[0m  0.0374\n"
+      "      1        \u001b[36m0.6905\u001b[0m       \u001b[32m0.6150\u001b[0m        \u001b[35m0.6749\u001b[0m  0.2752\n",
+      "      2        \u001b[36m0.6648\u001b[0m       \u001b[32m0.6450\u001b[0m        \u001b[35m0.6633\u001b[0m  0.0091\n",
+      "      3        \u001b[36m0.6619\u001b[0m       \u001b[32m0.6750\u001b[0m        \u001b[35m0.6533\u001b[0m  0.0088\n",
+      "      4        \u001b[36m0.6429\u001b[0m       \u001b[32m0.6800\u001b[0m        \u001b[35m0.6399\u001b[0m  0.0090\n",
+      "      5        \u001b[36m0.6307\u001b[0m       \u001b[32m0.6950\u001b[0m        \u001b[35m0.6254\u001b[0m  0.0090\n",
+      "      6        \u001b[36m0.6291\u001b[0m       \u001b[32m0.7000\u001b[0m        \u001b[35m0.6134\u001b[0m  0.0090\n",
+      "      7        \u001b[36m0.6102\u001b[0m       \u001b[32m0.7100\u001b[0m        \u001b[35m0.6033\u001b[0m  0.0087\n",
+      "      8        \u001b[36m0.6050\u001b[0m       0.7000        \u001b[35m0.5931\u001b[0m  0.0091\n",
+      "      9        \u001b[36m0.5966\u001b[0m       0.7000        \u001b[35m0.5844\u001b[0m  0.0090\n",
+      "     10        \u001b[36m0.5636\u001b[0m       0.7100        \u001b[35m0.5689\u001b[0m  0.0091\n",
+      "     11        0.5757       \u001b[32m0.7200\u001b[0m        \u001b[35m0.5628\u001b[0m  0.0089\n",
+      "     12        0.5757       0.7200        \u001b[35m0.5520\u001b[0m  0.0090\n",
+      "     13        \u001b[36m0.5559\u001b[0m       \u001b[32m0.7300\u001b[0m        \u001b[35m0.5459\u001b[0m  0.0089\n",
+      "     14        \u001b[36m0.5541\u001b[0m       0.7300        \u001b[35m0.5424\u001b[0m  0.0089\n",
+      "     15        0.5659       \u001b[32m0.7350\u001b[0m        \u001b[35m0.5378\u001b[0m  0.0089\n",
+      "     16        \u001b[36m0.5364\u001b[0m       0.7350        \u001b[35m0.5322\u001b[0m  0.0089\n",
+      "     17        0.5456       0.7300        \u001b[35m0.5239\u001b[0m  0.0090\n",
+      "     18        0.5476       \u001b[32m0.7450\u001b[0m        0.5260  0.0089\n",
+      "     19        0.5499       \u001b[32m0.7500\u001b[0m        0.5249  0.0088\n",
+      "     20        \u001b[36m0.5273\u001b[0m       0.7350        0.5251  0.0089\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<class 'skorch.net.NeuralNetClassifier'>[initialized](\n",
+       "<class 'skorch.classifier.NeuralNetClassifier'>[initialized](\n",
        "  module_=ClassifierModule(\n",
        "    (dense0): Linear(in_features=20, out_features=10, bias=True)\n",
        "    (dropout): Dropout(p=0.5)\n",
@@ -345,11 +345,11 @@
     {
      "data": {
       "text/plain": [
-       "array([[ 0.54967165,  0.45032835],\n",
-       "       [ 0.78423566,  0.21576437],\n",
-       "       [ 0.67652142,  0.32347855],\n",
-       "       [ 0.88522649,  0.1147735 ],\n",
-       "       [ 0.68577135,  0.31422862]], dtype=float32)"
+       "array([[0.5349464 , 0.46505365],\n",
+       "       [0.8685093 , 0.1314907 ],\n",
+       "       [0.6860039 , 0.31399614],\n",
+       "       [0.9126012 , 0.08739878],\n",
+       "       [0.69675475, 0.30324525]], dtype=float32)"
       ]
      },
      "execution_count": 12,
@@ -407,7 +407,7 @@
     {
      "data": {
       "text/plain": [
-       "((1000, 20), (1000, 1), -6.4901485, 6.1545048)"
+       "((1000, 20), (1000, 1), -6.4901485, 6.154505)"
       ]
      },
      "execution_count": 15,
@@ -488,7 +488,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from skorch.net import NeuralNetRegressor"
+    "from skorch import NeuralNetRegressor"
    ]
   },
   {
@@ -501,7 +501,7 @@
     "    RegressorModule,\n",
     "    max_epochs=20,\n",
     "    lr=0.1,\n",
-    "    # device='cuda',  # uncomment this to train with CUDA\n",
+    "#     device='cuda',  # uncomment this to train with CUDA\n",
     ")"
    ]
   },
@@ -516,32 +516,32 @@
      "text": [
       "  epoch    train_loss    valid_loss     dur\n",
       "-------  ------------  ------------  ------\n",
-      "      1        \u001b[36m4.6059\u001b[0m        \u001b[32m3.5860\u001b[0m  0.0337\n",
-      "      2        \u001b[36m3.5021\u001b[0m        \u001b[32m1.3814\u001b[0m  0.0251\n",
-      "      3        \u001b[36m1.1019\u001b[0m        \u001b[32m0.5334\u001b[0m  0.0253\n",
-      "      4        \u001b[36m0.7071\u001b[0m        \u001b[32m0.2994\u001b[0m  0.0388\n",
-      "      5        \u001b[36m0.5654\u001b[0m        0.4141  0.0299\n",
-      "      6        \u001b[36m0.3179\u001b[0m        \u001b[32m0.1574\u001b[0m  0.0272\n",
-      "      7        \u001b[36m0.2476\u001b[0m        0.1906  0.0289\n",
-      "      8        \u001b[36m0.1302\u001b[0m        \u001b[32m0.1049\u001b[0m  0.0274\n",
-      "      9        0.1373        0.1124  0.0274\n",
-      "     10        \u001b[36m0.0728\u001b[0m        \u001b[32m0.0737\u001b[0m  0.0294\n",
-      "     11        0.0839        \u001b[32m0.0727\u001b[0m  0.0362\n",
-      "     12        \u001b[36m0.0435\u001b[0m        \u001b[32m0.0513\u001b[0m  0.0335\n",
-      "     13        0.0508        \u001b[32m0.0483\u001b[0m  0.0300\n",
-      "     14        \u001b[36m0.0279\u001b[0m        \u001b[32m0.0371\u001b[0m  0.0306\n",
-      "     15        0.0322        \u001b[32m0.0335\u001b[0m  0.0291\n",
-      "     16        \u001b[36m0.0193\u001b[0m        \u001b[32m0.0282\u001b[0m  0.0300\n",
-      "     17        0.0224        \u001b[32m0.0247\u001b[0m  0.0306\n",
-      "     18        \u001b[36m0.0148\u001b[0m        \u001b[32m0.0221\u001b[0m  0.0294\n",
-      "     19        0.0167        \u001b[32m0.0198\u001b[0m  0.0354\n",
-      "     20        \u001b[36m0.0122\u001b[0m        \u001b[32m0.0182\u001b[0m  0.0328\n"
+      "      1        \u001b[36m4.4168\u001b[0m        \u001b[32m3.0788\u001b[0m  0.0252\n",
+      "      2        \u001b[36m2.0120\u001b[0m        \u001b[32m0.4565\u001b[0m  0.0100\n",
+      "      3        \u001b[36m0.3343\u001b[0m        \u001b[32m0.2262\u001b[0m  0.0098\n",
+      "      4        \u001b[36m0.1851\u001b[0m        \u001b[32m0.2223\u001b[0m  0.0098\n",
+      "      5        \u001b[36m0.1491\u001b[0m        \u001b[32m0.1068\u001b[0m  0.0098\n",
+      "      6        \u001b[36m0.0946\u001b[0m        0.1207  0.0099\n",
+      "      7        \u001b[36m0.0739\u001b[0m        \u001b[32m0.0663\u001b[0m  0.0098\n",
+      "      8        \u001b[36m0.0554\u001b[0m        0.0706  0.0097\n",
+      "      9        \u001b[36m0.0437\u001b[0m        \u001b[32m0.0461\u001b[0m  0.0099\n",
+      "     10        \u001b[36m0.0372\u001b[0m        0.0469  0.0097\n",
+      "     11        \u001b[36m0.0291\u001b[0m        \u001b[32m0.0343\u001b[0m  0.0098\n",
+      "     12        \u001b[36m0.0270\u001b[0m        \u001b[32m0.0333\u001b[0m  0.0099\n",
+      "     13        \u001b[36m0.0207\u001b[0m        \u001b[32m0.0265\u001b[0m  0.0098\n",
+      "     14        \u001b[36m0.0196\u001b[0m        \u001b[32m0.0249\u001b[0m  0.0098\n",
+      "     15        \u001b[36m0.0152\u001b[0m        \u001b[32m0.0215\u001b[0m  0.0099\n",
+      "     16        \u001b[36m0.0151\u001b[0m        \u001b[32m0.0198\u001b[0m  0.0098\n",
+      "     17        \u001b[36m0.0120\u001b[0m        \u001b[32m0.0182\u001b[0m  0.0097\n",
+      "     18        \u001b[36m0.0119\u001b[0m        \u001b[32m0.0167\u001b[0m  0.0099\n",
+      "     19        \u001b[36m0.0100\u001b[0m        \u001b[32m0.0159\u001b[0m  0.0097\n",
+      "     20        \u001b[36m0.0097\u001b[0m        \u001b[32m0.0149\u001b[0m  0.0098\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<class 'skorch.net.NeuralNetRegressor'>[initialized](\n",
+       "<class 'skorch.regressor.NeuralNetRegressor'>[initialized](\n",
        "  module_=RegressorModule(\n",
        "    (dense0): Linear(in_features=20, out_features=10, bias=True)\n",
        "    (dense1): Linear(in_features=10, out_features=10, bias=True)\n",
@@ -581,11 +581,11 @@
     {
      "data": {
       "text/plain": [
-       "array([[ 0.52162164],\n",
-       "       [-1.50998151],\n",
-       "       [-0.90007448],\n",
-       "       [-0.08845913],\n",
-       "       [-0.52214217]], dtype=float32)"
+       "array([[ 0.4903931 ],\n",
+       "       [-1.4224019 ],\n",
+       "       [-0.77500594],\n",
+       "       [-0.06901944],\n",
+       "       [-0.3867012 ]], dtype=float32)"
       ]
      },
      "execution_count": 20,
@@ -648,7 +648,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/marian/anaconda3/envs/skorch/lib/python3.6/site-packages/torch/serialization.py:193: UserWarning: Couldn't retrieve source code for container of type ClassifierModule. It won't be checked for correctness upon loading.\n",
+      "/home/thomasfan/anaconda3/lib/python3.6/site-packages/torch/serialization.py:241: UserWarning: Couldn't retrieve source code for container of type ClassifierModule. It won't be checked for correctness upon loading.\n",
       "  \"type \" + obj.__name__ + \". It won't be checked \"\n"
      ]
     }
@@ -762,33 +762,33 @@
       "Re-initializing module!\n",
       "  epoch    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ------------  -----------  ------------  ------\n",
-      "      1        \u001b[36m0.6891\u001b[0m       \u001b[32m0.5550\u001b[0m        \u001b[35m0.6853\u001b[0m  0.0454\n",
-      "      2        \u001b[36m0.6826\u001b[0m       \u001b[32m0.5600\u001b[0m        \u001b[35m0.6825\u001b[0m  0.0426\n",
-      "      3        0.6873       \u001b[32m0.5900\u001b[0m        \u001b[35m0.6801\u001b[0m  0.0389\n",
-      "      4        \u001b[36m0.6797\u001b[0m       \u001b[32m0.6000\u001b[0m        \u001b[35m0.6776\u001b[0m  0.0355\n",
-      "      5        \u001b[36m0.6772\u001b[0m       \u001b[32m0.6150\u001b[0m        \u001b[35m0.6751\u001b[0m  0.0352\n",
-      "      6        \u001b[36m0.6748\u001b[0m       \u001b[32m0.6200\u001b[0m        \u001b[35m0.6723\u001b[0m  0.0452\n",
-      "      7        \u001b[36m0.6682\u001b[0m       0.6200        \u001b[35m0.6691\u001b[0m  0.0392\n",
-      "      8        \u001b[36m0.6645\u001b[0m       0.6200        \u001b[35m0.6654\u001b[0m  0.0352\n",
-      "      9        \u001b[36m0.6623\u001b[0m       \u001b[32m0.6300\u001b[0m        \u001b[35m0.6613\u001b[0m  0.0351\n",
-      "     10        \u001b[36m0.6464\u001b[0m       0.6200        \u001b[35m0.6555\u001b[0m  0.0355\n",
-      "     11        0.6471       0.6300        \u001b[35m0.6491\u001b[0m  0.0360\n",
-      "     12        \u001b[36m0.6449\u001b[0m       \u001b[32m0.6600\u001b[0m        \u001b[35m0.6424\u001b[0m  0.0377\n",
-      "     13        \u001b[36m0.6285\u001b[0m       0.6500        \u001b[35m0.6341\u001b[0m  0.0367\n",
-      "     14        \u001b[36m0.6265\u001b[0m       0.6500        \u001b[35m0.6261\u001b[0m  0.0352\n",
-      "     15        \u001b[36m0.6252\u001b[0m       0.6600        \u001b[35m0.6193\u001b[0m  0.0376\n",
-      "     16        \u001b[36m0.6148\u001b[0m       \u001b[32m0.6750\u001b[0m        \u001b[35m0.6102\u001b[0m  0.0375\n",
-      "     17        \u001b[36m0.6039\u001b[0m       \u001b[32m0.6850\u001b[0m        \u001b[35m0.6017\u001b[0m  0.0375\n",
-      "     18        \u001b[36m0.5979\u001b[0m       \u001b[32m0.6900\u001b[0m        \u001b[35m0.5949\u001b[0m  0.0382\n",
-      "     19        \u001b[36m0.5794\u001b[0m       \u001b[32m0.7000\u001b[0m        \u001b[35m0.5849\u001b[0m  0.0385\n",
-      "     20        \u001b[36m0.5596\u001b[0m       \u001b[32m0.7050\u001b[0m        \u001b[35m0.5758\u001b[0m  0.0379\n"
+      "      1        \u001b[36m0.7243\u001b[0m       \u001b[32m0.5000\u001b[0m        \u001b[35m0.7105\u001b[0m  0.0087\n",
+      "      2        \u001b[36m0.7057\u001b[0m       0.5000        \u001b[35m0.6996\u001b[0m  0.0089\n",
+      "      3        \u001b[36m0.6971\u001b[0m       0.5000        \u001b[35m0.6949\u001b[0m  0.0089\n",
+      "      4        \u001b[36m0.6936\u001b[0m       \u001b[32m0.5050\u001b[0m        \u001b[35m0.6929\u001b[0m  0.0089\n",
+      "      5        \u001b[36m0.6923\u001b[0m       \u001b[32m0.5400\u001b[0m        \u001b[35m0.6916\u001b[0m  0.0088\n",
+      "      6        \u001b[36m0.6905\u001b[0m       0.5000        \u001b[35m0.6906\u001b[0m  0.0088\n",
+      "      7        \u001b[36m0.6894\u001b[0m       0.5100        \u001b[35m0.6899\u001b[0m  0.0088\n",
+      "      8        \u001b[36m0.6891\u001b[0m       0.5150        \u001b[35m0.6892\u001b[0m  0.0088\n",
+      "      9        0.6899       0.5250        \u001b[35m0.6885\u001b[0m  0.0088\n",
+      "     10        \u001b[36m0.6844\u001b[0m       0.5300        \u001b[35m0.6876\u001b[0m  0.0088\n",
+      "     11        0.6853       \u001b[32m0.5650\u001b[0m        \u001b[35m0.6865\u001b[0m  0.0089\n",
+      "     12        \u001b[36m0.6842\u001b[0m       \u001b[32m0.5700\u001b[0m        \u001b[35m0.6855\u001b[0m  0.0088\n",
+      "     13        \u001b[36m0.6821\u001b[0m       \u001b[32m0.5850\u001b[0m        \u001b[35m0.6844\u001b[0m  0.0089\n",
+      "     14        \u001b[36m0.6821\u001b[0m       \u001b[32m0.6050\u001b[0m        \u001b[35m0.6832\u001b[0m  0.0088\n",
+      "     15        \u001b[36m0.6820\u001b[0m       \u001b[32m0.6100\u001b[0m        \u001b[35m0.6820\u001b[0m  0.0088\n",
+      "     16        \u001b[36m0.6769\u001b[0m       0.6100        \u001b[35m0.6800\u001b[0m  0.0088\n",
+      "     17        0.6784       \u001b[32m0.6200\u001b[0m        \u001b[35m0.6780\u001b[0m  0.0088\n",
+      "     18        \u001b[36m0.6763\u001b[0m       \u001b[32m0.6450\u001b[0m        \u001b[35m0.6761\u001b[0m  0.0088\n",
+      "     19        \u001b[36m0.6704\u001b[0m       \u001b[32m0.6550\u001b[0m        \u001b[35m0.6729\u001b[0m  0.0088\n",
+      "     20        \u001b[36m0.6691\u001b[0m       \u001b[32m0.6750\u001b[0m        \u001b[35m0.6699\u001b[0m  0.0088\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "Pipeline(memory=None,\n",
-       "     steps=[('scale', StandardScaler(copy=True, with_mean=True, with_std=True)), ('net', <class 'skorch.net.NeuralNetClassifier'>[initialized](\n",
+       "     steps=[('scale', StandardScaler(copy=True, with_mean=True, with_std=True)), ('net', <class 'skorch.classifier.NeuralNetClassifier'>[initialized](\n",
        "  module_=ClassifierModule(\n",
        "    (dense0): Linear(in_features=20, out_features=10, bias=True)\n",
        "    (dropout): Dropout(p=0.5)\n",
@@ -815,11 +815,11 @@
     {
      "data": {
       "text/plain": [
-       "array([[ 0.39650354,  0.60349649],\n",
-       "       [ 0.73950189,  0.26049814],\n",
-       "       [ 0.72104084,  0.27895918],\n",
-       "       [ 0.71111423,  0.2888858 ],\n",
-       "       [ 0.66332668,  0.33667329]], dtype=float32)"
+       "array([[0.5064775 , 0.49352255],\n",
+       "       [0.5324396 , 0.46756035],\n",
+       "       [0.57306874, 0.42693123],\n",
+       "       [0.54179883, 0.4582012 ],\n",
+       "       [0.5528906 , 0.44710943]], dtype=float32)"
       ]
      },
      "execution_count": 31,
@@ -923,32 +923,32 @@
      "text": [
       "  epoch    roc_auc    train_loss    valid_acc    valid_loss     dur\n",
       "-------  ---------  ------------  -----------  ------------  ------\n",
-      "      1     \u001b[36m0.5911\u001b[0m        \u001b[32m0.7204\u001b[0m       \u001b[35m0.5000\u001b[0m        \u001b[31m0.6948\u001b[0m  0.0438\n",
-      "      2     \u001b[36m0.6524\u001b[0m        \u001b[32m0.6925\u001b[0m       \u001b[35m0.5300\u001b[0m        \u001b[31m0.6881\u001b[0m  0.0484\n",
-      "      3     \u001b[36m0.6700\u001b[0m        \u001b[32m0.6867\u001b[0m       \u001b[35m0.6000\u001b[0m        \u001b[31m0.6857\u001b[0m  0.0415\n",
-      "      4     \u001b[36m0.6854\u001b[0m        \u001b[32m0.6820\u001b[0m       \u001b[35m0.6400\u001b[0m        \u001b[31m0.6832\u001b[0m  0.0460\n",
-      "      5     0.6829        \u001b[32m0.6801\u001b[0m       0.6050        \u001b[31m0.6812\u001b[0m  0.0404\n",
-      "      6     0.6757        \u001b[32m0.6742\u001b[0m       0.6100        \u001b[31m0.6796\u001b[0m  0.0382\n",
-      "      7     0.6808        0.6762       0.6100        \u001b[31m0.6776\u001b[0m  0.0354\n",
-      "      8     0.6759        \u001b[32m0.6576\u001b[0m       0.6350        \u001b[31m0.6747\u001b[0m  0.0344\n",
-      "      9     0.6813        0.6661       0.6350        \u001b[31m0.6707\u001b[0m  0.0352\n",
-      "     10     \u001b[36m0.6903\u001b[0m        \u001b[32m0.6548\u001b[0m       \u001b[35m0.6450\u001b[0m        \u001b[31m0.6655\u001b[0m  0.0352\n",
-      "     11     \u001b[36m0.6929\u001b[0m        \u001b[32m0.6500\u001b[0m       0.6400        \u001b[31m0.6611\u001b[0m  0.0370\n",
-      "     12     0.6920        \u001b[32m0.6445\u001b[0m       \u001b[35m0.6500\u001b[0m        \u001b[31m0.6571\u001b[0m  0.0369\n",
-      "     13     \u001b[36m0.7095\u001b[0m        \u001b[32m0.6372\u001b[0m       \u001b[35m0.6650\u001b[0m        \u001b[31m0.6509\u001b[0m  0.0364\n",
-      "     14     \u001b[36m0.7155\u001b[0m        \u001b[32m0.6288\u001b[0m       \u001b[35m0.6700\u001b[0m        \u001b[31m0.6446\u001b[0m  0.0404\n",
-      "     15     \u001b[36m0.7265\u001b[0m        \u001b[32m0.6268\u001b[0m       0.6700        \u001b[31m0.6390\u001b[0m  0.0343\n",
-      "     16     \u001b[36m0.7398\u001b[0m        \u001b[32m0.6150\u001b[0m       \u001b[35m0.6900\u001b[0m        \u001b[31m0.6308\u001b[0m  0.0379\n",
-      "     17     \u001b[36m0.7487\u001b[0m        0.6221       \u001b[35m0.7000\u001b[0m        \u001b[31m0.6246\u001b[0m  0.0412\n",
-      "     18     0.7473        0.6168       \u001b[35m0.7250\u001b[0m        \u001b[31m0.6187\u001b[0m  0.0442\n",
-      "     19     \u001b[36m0.7588\u001b[0m        \u001b[32m0.5945\u001b[0m       \u001b[35m0.7400\u001b[0m        \u001b[31m0.6100\u001b[0m  0.0449\n",
-      "     20     \u001b[36m0.7664\u001b[0m        0.6000       \u001b[35m0.7650\u001b[0m        \u001b[31m0.6026\u001b[0m  0.0458\n"
+      "      1     \u001b[36m0.6112\u001b[0m        \u001b[32m0.7076\u001b[0m       \u001b[35m0.5550\u001b[0m        \u001b[31m0.6802\u001b[0m  0.0088\n",
+      "      2     \u001b[36m0.6766\u001b[0m        \u001b[32m0.6750\u001b[0m       \u001b[35m0.6150\u001b[0m        \u001b[31m0.6626\u001b[0m  0.0091\n",
+      "      3     \u001b[36m0.7031\u001b[0m        \u001b[32m0.6560\u001b[0m       \u001b[35m0.6500\u001b[0m        \u001b[31m0.6498\u001b[0m  0.0089\n",
+      "      4     \u001b[36m0.7201\u001b[0m        \u001b[32m0.6364\u001b[0m       \u001b[35m0.6650\u001b[0m        \u001b[31m0.6381\u001b[0m  0.0089\n",
+      "      5     \u001b[36m0.7316\u001b[0m        \u001b[32m0.6176\u001b[0m       \u001b[35m0.6900\u001b[0m        \u001b[31m0.6285\u001b[0m  0.0089\n",
+      "      6     \u001b[36m0.7447\u001b[0m        \u001b[32m0.6094\u001b[0m       \u001b[35m0.7200\u001b[0m        \u001b[31m0.6183\u001b[0m  0.0088\n",
+      "      7     \u001b[36m0.7522\u001b[0m        0.6170       0.7200        \u001b[31m0.6090\u001b[0m  0.0088\n",
+      "      8     \u001b[36m0.7567\u001b[0m        \u001b[32m0.5786\u001b[0m       0.7150        \u001b[31m0.6032\u001b[0m  0.0089\n",
+      "      9     \u001b[36m0.7630\u001b[0m        0.5850       0.7100        \u001b[31m0.5954\u001b[0m  0.0089\n",
+      "     10     \u001b[36m0.7706\u001b[0m        \u001b[32m0.5770\u001b[0m       0.7200        \u001b[31m0.5889\u001b[0m  0.0089\n",
+      "     11     \u001b[36m0.7735\u001b[0m        \u001b[32m0.5740\u001b[0m       0.7050        \u001b[31m0.5842\u001b[0m  0.0089\n",
+      "     12     0.7729        0.5771       0.7100        0.5859  0.0089\n",
+      "     13     \u001b[36m0.7792\u001b[0m        \u001b[32m0.5557\u001b[0m       0.7000        \u001b[31m0.5745\u001b[0m  0.0089\n",
+      "     14     \u001b[36m0.7825\u001b[0m        0.5810       0.7050        \u001b[31m0.5691\u001b[0m  0.0088\n",
+      "     15     0.7824        0.5634       0.7200        \u001b[31m0.5691\u001b[0m  0.0089\n",
+      "     16     0.7817        0.5778       0.7150        0.5704  0.0088\n",
+      "     17     \u001b[36m0.7871\u001b[0m        0.5624       0.7150        \u001b[31m0.5633\u001b[0m  0.0091\n",
+      "     18     0.7855        0.5613       0.7200        0.5660  0.0088\n",
+      "     19     0.7792        0.5637       \u001b[35m0.7250\u001b[0m        0.5722  0.0089\n",
+      "     20     0.7823        \u001b[32m0.5516\u001b[0m       0.7150        0.5681  0.0089\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<class 'skorch.net.NeuralNetClassifier'>[initialized](\n",
+       "<class 'skorch.classifier.NeuralNetClassifier'>[initialized](\n",
        "  module_=ClassifierModule(\n",
        "    (dense0): Linear(in_features=20, out_features=10, bias=True)\n",
        "    (dropout): Dropout(p=0.5)\n",
@@ -1100,7 +1100,9 @@
      "text": [
       "Fitting 3 folds for each of 16 candidates, totalling 48 fits\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=False, total=   0.7s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=False, total=   0.2s\n",
+      "[CV] lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=False \n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=False \n"
      ]
     },
@@ -1108,126 +1110,118 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    0.7s remaining:    0.0s\n"
+      "[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    0.2s remaining:    0.0s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=False, total=   0.6s\n",
-      "[CV] lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=10, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0, module__num_units=20, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False, total=   0.7s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False, total=   0.7s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True, total=   0.7s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True, total=   0.8s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True \n",
-      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.05, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=10, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=True, total=   0.7s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0, module__num_units=20, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=10, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=False, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True, total=   0.6s\n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True, total=   0.2s\n",
       "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True \n",
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True, total=   0.6s\n",
-      "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True, total=   0.6s\n"
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True, total=   0.2s\n",
+      "[CV] lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True \n",
+      "[CV]  lr=0.1, module__dropout=0.5, module__num_units=20, optimizer__nesterov=True, total=   0.2s\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[Parallel(n_jobs=1)]: Done  48 out of  48 | elapsed:   30.3s finished\n"
+      "[Parallel(n_jobs=1)]: Done  48 out of  48 | elapsed:    8.2s finished\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "GridSearchCV(cv=3, error_score='raise',\n",
-       "       estimator=<class 'skorch.net.NeuralNetClassifier'>[uninitialized](\n",
+       "       estimator=<class 'skorch.classifier.NeuralNetClassifier'>[uninitialized](\n",
        "  module=<class '__main__.ClassifierModule'>,\n",
        "),\n",
        "       fit_params=None, iid=True, n_jobs=1,\n",
@@ -1256,7 +1250,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.856 {'lr': 0.1, 'module__dropout': 0, 'module__num_units': 20, 'optimizer__nesterov': False}\n"
+      "0.862 {'lr': 0.05, 'module__dropout': 0, 'module__num_units': 20, 'optimizer__nesterov': False}\n"
      ]
     }
    ],
@@ -1272,13 +1266,6 @@
    "source": [
     "Of course, we could further nest the `NeuralNetClassifier` within an `sklearn Pipeline`, in which case we just prefix the parameter by the name of the net (e.g. `net__module__num_units`)."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1297,7 +1284,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/skorch/__init__.py
+++ b/skorch/__init__.py
@@ -10,7 +10,7 @@ from .regressor import NeuralNetRegressor
 from . import callbacks
 
 
-MIN_TORCH_VERSION = '0.4.0'
+MIN_TORCH_VERSION = '0.4.1'
 
 try:
     # pylint: disable=wrong-import-position

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -352,7 +352,7 @@ class NeuralNetBinaryClassifier(NeuralNet):
         for yp in self.forward_iter(X, training=False):
             yp = yp[0] if isinstance(yp, tuple) else yp
             if bce_logits_loss:
-                yp = torch.nn.functional.sigmoid(yp)
+                yp = torch.sigmoid(yp)
             y_probas.append(to_numpy(yp))
         y_proba = np.concatenate(y_probas, 0)
         return y_proba

--- a/skorch/dataset.py
+++ b/skorch/dataset.py
@@ -50,10 +50,10 @@ def get_len(data):
 def uses_placeholder_y(ds):
     """If ``ds`` is a ``skorch.dataset.Dataset`` or a
     ``skorch.dataset.Dataset`` nested inside a
-    ``torch.utils.data.dataset.Subset`` and uses
+    ``torch.utils.data.Subset`` and uses
     y as a placeholder, return ``True``."""
 
-    if isinstance(ds, torch.utils.data.dataset.Subset):
+    if isinstance(ds, torch.utils.data.Subset):
         return uses_placeholder_y(ds.dataset)
     return isinstance(ds, Dataset) and ds.y is None
 
@@ -274,8 +274,8 @@ class CVSplit(object):
             args = args + (to_numpy(y),)
 
         idx_train, idx_valid = next(iter(cv.split(*args, groups=groups)))
-        dataset_train = torch.utils.data.dataset.Subset(dataset, idx_train)
-        dataset_valid = torch.utils.data.dataset.Subset(dataset, idx_valid)
+        dataset_train = torch.utils.data.Subset(dataset, idx_train)
+        dataset_valid = torch.utils.data.Subset(dataset, idx_valid)
         return dataset_train, dataset_valid
 
     def __repr__(self):

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -84,10 +84,10 @@ class TestNeuralNet:
         X = data[0]
 
         y_proba = net_fit.predict_proba(X)
-        assert np.allclose(y_proba.sum(1), 1, rtol=1e-7)
+        assert np.allclose(y_proba.sum(1), 1, rtol=1e-5)
 
         y_pred = net_fit.predict(X)
-        assert np.allclose(np.argmax(y_proba, 1), y_pred, rtol=1e-7)
+        assert np.allclose(np.argmax(y_proba, 1), y_pred, rtol=1e-5)
 
     # classifier-specific test
     def test_takes_log_with_nllloss(self, net_cls, module_cls, data):
@@ -212,7 +212,7 @@ class TestNeuralNetBinaryClassifier:
     def test_custom_loss_does_not_call_sigmoid(
             self, net_cls, data, module_cls, monkeypatch):
         mock = Mock(side_effect=lambda x: x)
-        monkeypatch.setattr(torch.nn.functional, "sigmoid", mock)
+        monkeypatch.setattr(torch, "sigmoid", mock)
 
         net = net_cls(module_cls, max_epochs=1, lr=0.1, criterion=nn.MSELoss)
         X, y = data
@@ -224,7 +224,7 @@ class TestNeuralNetBinaryClassifier:
     def test_default_loss_does_call_sigmoid(
             self, net_cls, data, module_cls, monkeypatch):
         mock = Mock(side_effect=lambda x: x)
-        monkeypatch.setattr(torch.nn.functional, "sigmoid", mock)
+        monkeypatch.setattr(torch, "sigmoid", mock)
 
         net = net_cls(module_cls, max_epochs=1, lr=0.1)
         X, y = data

--- a/skorch/tests/test_dataset.py
+++ b/skorch/tests/test_dataset.py
@@ -503,7 +503,7 @@ class TestTrainSplitIsUsed:
 
     @pytest.fixture
     def data(self):
-        X = torch.arange(0, 12).view(4, 3)
+        X = torch.arange(0, 12, dtype=torch.float32).view(4, 3)
         y = torch.LongTensor([0, 1, 1, 0])
         return X, y
 

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -409,14 +409,14 @@ class TestNeuralNet:
 
         net.set_params(
             module__num_units=20,
-            module__nonlin=F.tanh,
+            module__nonlin=torch.tanh,
             lr=0.2,
         )
         net.fit(X, y)
 
         assert net.module_.dense0.out_features == 20
         assert net.module_.dense1.in_features == 20
-        assert net.module_.nonlin is F.tanh
+        assert net.module_.nonlin is torch.tanh
         assert np.isclose(net.lr, 0.2)
 
     def test_set_params_then_initialize_remembers_param(
@@ -493,13 +493,13 @@ class TestNeuralNet:
         net = net_cls(
             module=module_cls,
             module__num_units=20,
-            module__nonlin=F.tanh,
+            module__nonlin=torch.tanh,
         )
         net.fit(X, y)
 
         assert net.module_.dense0.out_features == 20
         assert net.module_.dense1.in_features == 20
-        assert net.module_.nonlin is F.tanh
+        assert net.module_.nonlin is torch.tanh
 
     def test_module_initialized_with_partial_module(self, net_cls, module_cls):
         net = net_cls(partial(module_cls, num_units=123))

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -68,11 +68,11 @@ def to_tensor(X, device):
     elif isinstance(X, (list, tuple)):
         return [to_tensor_(x) for x in X]
     elif np.isscalar(X):
-        return torch.tensor(X).to(device)
+        return torch.as_tensor(X, device=device)
     elif isinstance(X, Sequence):
-        return torch.tensor(np.array(X)).to(device)
+        return torch.as_tensor(np.array(X), device=device)
     elif isinstance(X, np.ndarray):
-        return torch.tensor(X).to(device)
+        return torch.as_tensor(X, device=device)
     elif isinstance(X, nn.utils.rnn.PackedSequence):
         return X
     else:

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -359,7 +359,7 @@ def data_from_dataset(dataset, X_indexing=None, y_indexing=None):
 def is_skorch_dataset(ds):
     """Checks if the supplied dataset is an instance of
     ``skorch.dataset.Dataset`` even when it is nested inside
-    ``torch.util.data.dataset.Subset``."""
+    ``torch.util.data.Subset``."""
     from skorch.dataset import Dataset
     if isinstance(ds, Subset):
         return is_skorch_dataset(ds.dataset)

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -327,9 +327,9 @@ def data_from_dataset(dataset, X_indexing=None, y_indexing=None):
 
     Parameters
     ----------
-    dataset : skorch.dataset.Dataset or torch.utils.data.dataset.Subset
+    dataset : skorch.dataset.Dataset or torch.utils.data.Subset
       The incoming dataset should be a ``skorch.dataset.Dataset`` or a
-      ``torch.utils.data.dataset.Subset`` of a
+      ``torch.utils.data.Subset`` of a
       ``skorch.dataset.Dataset``.
 
     X_indexing : function/callable or None (default=None)


### PR DESCRIPTION
This PR updates skorch to support PyTorch 0.4.1. There is one small optimization to `skorch.utils. to_tensor` by using [`torch.as_tensor`](https://pytorch.org/docs/stable/torch.html#torch.as_tensor), which never copies unless necessary.