### PR TITLE
ENH: Prints header on train start

### DIFF
--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -106,6 +106,9 @@ class PrintLog(Callback):
         self.keys_ignored_.add('batches')
         return self
 
+    def on_train_begin(self, net, **kwargs):
+        self.first_iteration_ = True
+
     def format_row(self, row, key, color):
         """For a given row from the table, format it (i.e. floating
         points and color if applicable).

--- a/skorch/tests/callbacks/test_logging.py
+++ b/skorch/tests/callbacks/test_logging.py
@@ -74,6 +74,13 @@ class TestPrintLog:
         expected = ['epoch', 'nmse', 'train_loss', 'valid_loss']
         assert columns == expected
 
+    def test_header_partial_fit(self, net, data, sink):
+        net.partial_fit(*data)
+        second_header = sink.call_args_list[4][0][0]
+        columns = second_header.split()
+        expected = ['epoch', 'nmse', 'train_loss', 'valid_loss']
+        assert columns == expected
+
     def test_lines(self, sink):
         lines = sink.call_args_list[1][0][0].split()
         # Lines have length 2 + length of column, or 8 if the column


### PR DESCRIPTION
When `partial_fit` is called a second time, the header is not printed. This PR adds header printing before every train event.