### PR TITLE
On name conflict assign unique callback names

### DIFF
--- a/docs/user/callbacks.rst
+++ b/docs/user/callbacks.rst
@@ -88,6 +88,29 @@ update step was performed. Gets the module parameters as additional
 input. Useful if you want to tinker with gradients.
 
 
+Setting callback parameters
+---------------------------
+
+You can set specific callback parameters using the ususal `set_params`
+interface on the network by using the `callbacks__` prefix and the
+callback's name. For example to change the scoring order of the train
+loss you can write this:
+
+.. code:: python
+
+    net = NeuralNet()
+    net.set_params(callbacks__train_loss__lower_is_better=False)
+
+Changes will be applied on initialization and callbacks that
+are changed using `set_params` will be re-initialized.
+
+The name you use to address the callback can be chosen during
+initialization of the network and defaults to the class name.
+If there is a conflict, the conflicting names will be made unique
+by appending a count suffix starting at 1, e.g.
+``EpochScoring_1``, ``EpochScoring_2``, etc.
+
+
 Deactivating callbacks
 -----------------------
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -363,7 +363,7 @@ class NeuralNet(object):
         not unique, a ValueError is raised.
 
         """
-        names_seen = set()
+        names_seen = {}
         callbacks_ = []
 
         class Dummy:
@@ -372,11 +372,19 @@ class NeuralNet(object):
             pass
 
         for name, cb in self._yield_callbacks():
-            if name in names_seen:
-                raise ValueError("The callback name '{}' appears more than "
-                                 "once.".format(name))
-            names_seen.add(name)
+            names_seen[name] = names_seen.get(name, []) + [cb]
 
+        named_callbacks = []
+
+        for name, cbs in names_seen.items():
+            for i, cb in enumerate(cbs):
+                if len(cbs) > 1:
+                    unique_name = '{}_{}'.format(name, i+1)
+                else:
+                    unique_name = name
+                named_callbacks.append((unique_name, cb))
+
+        for name, cb in named_callbacks:
             # check if callback itself is changed
             param_callback = getattr(self, 'callbacks__' + name, Dummy)
             if param_callback is not Dummy:  # callback itself was set

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -145,14 +145,15 @@ class NeuralNet(object):
     callbacks : None or list of Callback instances (default=None)
       More callbacks, in addition to those returned by
       ``get_default_callbacks``. Each callback should inherit from
-      :class:`.Callback`. If not ``None``, a list of tuples (name,
-      callback) should be passed, where names should be unique.
-      Callbacks may or may not be instantiated.
-      Alternatively, it is possible to just pass a list of callbacks,
-      which results in names being inferred from the class name.
+      :class:`.Callback`. If not ``None``, a list of callbacks is
+      expected where the callback names are inferred from the class
+      name. Name conflicts are resolved by appending a count suffix
+      starting with 1, e.g. ``EpochScoring_1``. Alternatively,
+      a tuple ``(name, callback)`` can be passed, where ``name``
+      should be unique. Callbacks may or may not be instantiated.
       The callback name can be used to set parameters on specific
       callbacks (e.g., for the callback with name ``'print_log'``, use
-      ``net.set_params(callbacks__print_log__keys=['epoch',
+      ``net.set_params(callbacks__print_log__keys_ignored=['epoch',
       'train_loss'])``).
 
     warm_start : bool (default=False)
@@ -378,8 +379,8 @@ class NeuralNet(object):
                 if len(cbs) > 1:
                     unique_name = '{}_{}'.format(name, i+1)
                     if unique_name in grouped_cbs:
-                        raise ValueError("Setting unique name failed since "
-                                         "the new name '{}' exists already."
+                        raise ValueError("Assigning new callback name failed "
+                                         "since new name '{}' exists already."
                                          .format(unique_name))
                 else:
                     unique_name = name

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -368,8 +368,6 @@ class NeuralNet(object):
         same goes for the event where renaming leads to a conflict.
         """
         grouped_cbs, names_set_by_user = self._callbacks_grouped_by_name()
-        named_callbacks = []
-
         for name, cbs in grouped_cbs.items():
             if len(cbs) > 1 and name in names_set_by_user:
                 raise ValueError("Found duplicate user-set callback name "
@@ -385,9 +383,7 @@ class NeuralNet(object):
                                          .format(unique_name))
                 else:
                     unique_name = name
-
-                named_callbacks.append((unique_name, cb))
-        return named_callbacks
+                yield unique_name, cb
 
     def initialize_callbacks(self):
         """Initializes all callbacks and save the result in the
@@ -410,9 +406,7 @@ class NeuralNet(object):
             # legitimate value to be set.
             pass
 
-        named_callbacks = self._uniquely_named_callbacks()
-
-        for name, cb in named_callbacks:
+        for name, cb in self._uniquely_named_callbacks():
             # check if callback itself is changed
             param_callback = getattr(self, 'callbacks__' + name, Dummy)
             if param_callback is not Dummy:  # callback itself was set

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -547,22 +547,22 @@ class TestNeuralNet:
 
     def test_callback_name_collides_with_default(self, net_cls, module_cls):
         net = net_cls(module_cls, callbacks=[('train_loss', Mock())])
+        net.initialize()
+        cbs = dict(net.callbacks_)
 
-        with pytest.raises(ValueError) as exc:
-            net.initialize()
-        expected = "The callback name 'train_loss' appears more than once."
-        assert str(exc.value) == expected
+        assert 'train_loss_1' in cbs
+        assert 'train_loss_2' in cbs
 
     def test_callback_same_name_twice(self, net_cls, module_cls):
         callbacks = [('cb0', Mock()),
                      ('cb1', Mock()),
                      ('cb0', Mock())]
         net = net_cls(module_cls, callbacks=callbacks)
+        net.initialize()
+        cbs = dict(net.callbacks_)
 
-        with pytest.raises(ValueError) as exc:
-            net.initialize()
-        expected = "The callback name 'cb0' appears more than once."
-        assert str(exc.value) == expected
+        assert 'cb0_1' in cbs
+        assert 'cb0_2' in cbs
 
     def test_callback_same_inferred_name_twice(self, net_cls, module_cls):
         cb0 = Mock()
@@ -571,10 +571,13 @@ class TestNeuralNet:
         cb1.__class__.__name__ = 'some-name'
         net = net_cls(module_cls, callbacks=[cb0, cb1])
 
-        with pytest.raises(ValueError) as exc:
-            net.initialize()
-        expected = "The callback name 'some-name' appears more than once."
-        assert str(exc.value) == expected
+        net.initialize()
+
+        cbs = dict(net.callbacks_)
+        assert 'some-name_1' in cbs
+        assert 'some-name_2' in cbs
+        assert cbs['some-name_1'] is cb0
+        assert cbs['some-name_2'] is cb1
 
     def test_in_sklearn_pipeline(self, pipe, data):
         X, y = data

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -593,8 +593,9 @@ class TestNeuralNet:
         net = net_cls(module_cls, callbacks=callbacks)
         with pytest.raises(ValueError) as exc:
             net.initialize()
-        expected = ("Setting unique name failed since the "
-                    "new name 'cb0_1' exists already.")
+        expected = ("Assigning new callback name failed "
+                    "since new name 'cb0_1' exists already.")
+
         assert str(exc.value) == expected
 
     def test_in_sklearn_pipeline(self, pipe, data):


### PR DESCRIPTION
Callback names will be appended with a count suffix to
make the name unique if it appears more than once.
The suffix is of format `_{i}` with `i` starting at 1
with underscore as a separator to be addressable using
keywords arguments.

Example:

    e1 = EpochScoring(name='a')
    e2 = EpochScoring(name='b')
    net = Net(callbacks=[e1, e2]).initialize()
    cbs = dict(net.callbacks_)

Results in:

    cbs['EpochScoring_1'] == e1
    cbs['EpochScoring_2'] == e2

This addresses #294.