### PR TITLE
uses_placeholder_y should not require existence of "y" field

### DIFF
--- a/skorch/dataset.py
+++ b/skorch/dataset.py
@@ -55,7 +55,7 @@ def uses_placeholder_y(ds):
 
     if isinstance(ds, torch.utils.data.Subset):
         return uses_placeholder_y(ds.dataset)
-    return isinstance(ds, Dataset) and ds.y is None
+    return isinstance(ds, Dataset) and hasattr(ds, "y") and ds.y is None
 
 
 class Dataset(torch.utils.data.Dataset):

--- a/skorch/tests/test_dataset.py
+++ b/skorch/tests/test_dataset.py
@@ -69,6 +69,14 @@ class TestUsesPlaceholderY:
         return Dataset
 
     @pytest.fixture
+    def custom_dataset_cls(self):
+        from skorch.dataset import Dataset
+        class CustomDataset(Dataset):
+            def __init__(self):
+                pass
+        return CustomDataset
+
+    @pytest.fixture
     def cv_split_cls(self):
         from skorch.dataset import CVSplit
         return CVSplit
@@ -83,6 +91,11 @@ class TestUsesPlaceholderY:
             self, dataset_cls, data, uses_placeholder_y):
         X, y = data
         ds = dataset_cls(X, y)
+        assert not uses_placeholder_y(ds)
+
+    def test_custom_dataset_uses_non_y_placeholder(
+            self, custom_dataset_cls, uses_placeholder_y):
+        ds = custom_dataset_cls()
         assert not uses_placeholder_y(ds)
 
     def test_subset_uses_placeholder_y(


### PR DESCRIPTION
Fixes a problem mentioned #305.