### PR TITLE
Replace yield_fixture with fixture

### DIFF
--- a/skorch/tests/callbacks/test_logging.py
+++ b/skorch/tests/callbacks/test_logging.py
@@ -213,7 +213,7 @@ class TestPrintLog:
 
 
 class TestProgressBar:
-    @pytest.yield_fixture
+    @pytest.fixture
     def progressbar_cls(self):
         from skorch.callbacks import ProgressBar
         return ProgressBar

--- a/skorch/tests/callbacks/test_regularization.py
+++ b/skorch/tests/callbacks/test_regularization.py
@@ -7,7 +7,7 @@ from skorch.utils import to_numpy
 
 
 class TestGradientNormClipping:
-    @pytest.yield_fixture
+    @pytest.fixture
     def grad_clip_cls_and_mock(self):
         with patch('skorch.callbacks.regularization.clip_grad_norm_') as cgn:
             from skorch.callbacks import GradientNormClipping

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -9,23 +9,23 @@ import pytest
 
 
 class TestCheckpoint:
-    @pytest.yield_fixture
+    @pytest.fixture
     def checkpoint_cls(self):
         from skorch.callbacks import Checkpoint
         return Checkpoint
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def save_params_mock(self):
         with patch('skorch.NeuralNet.save_params') as mock:
             mock.side_effect = lambda x: x
             yield mock
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def save_history_mock(self):
         with patch('skorch.NeuralNet.save_history') as mock:
             yield mock
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def pickle_dump_mock(self):
         with patch('pickle.dump') as mock:
             yield mock


### PR DESCRIPTION
Standard `fixture` now supports yielding. `yield_fixture` has been deprecated since pytest 3.

See: https://docs.pytest.org/en/latest/yieldfixture.html