### PR TITLE
Remove superfluous call to is_dataset()

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -825,7 +825,7 @@ class NeuralNet(object):
           Result from a forward call on an individual batch.
 
         """
-        dataset = X if is_dataset(X) else self.get_dataset(X)
+        dataset = self.get_dataset(X)
         iterator = self.get_iterator(dataset, training=training)
         for Xi, _ in iterator:
             yp = self.evaluation_step(Xi, training=training)


### PR DESCRIPTION
This test is performed inside `get_dataset()` anyway.