### PR TITLE
Make tests work with Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.6"
+  - "3.5"
 cache:
   apt: true
   timeout: 1000

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.5"
 cache:
   apt: true
-  timeout: 1000
+  timeout: 1500
   directories:
     - $HOME/miniconda/pkgs/
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.5"
 cache:
   apt: true
-  timeout: 1500
+  timeout: 1000
   directories:
     - $HOME/cache
 before_cache:

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -254,7 +254,7 @@ class NeuralNet(object):
                    "Either you made a typo, or you added new arguments "
                    "in a subclass; if that is the case, the subclass "
                    "should deal with the new arguments explicitely.")
-            raise TypeError(msg.format(', '.join(unexpected_kwargs)))
+            raise TypeError(msg.format(', '.join(sorted(unexpected_kwargs))))
         vars(self).update(kwargs)
 
         self.history = history

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -5,12 +5,13 @@ that is general to NeuralNet class.
 
 """
 
+import copy
 from functools import partial
+from pathlib import Path
 import pickle
 from unittest.mock import Mock
 from unittest.mock import patch
-from pathlib import Path
-import copy
+import sys
 
 import numpy as np
 import pytest
@@ -188,7 +189,7 @@ class TestNeuralNet:
                     warm_start=False, bathc_size=20)
 
         expected = ("__init__() got unexpected argument(s) "
-                    "mxa_epochs, bathc_size. "
+                    "bathc_size, mxa_epochs. "
                     "Either you made a typo, or you added new arguments "
                     "in a subclass; if that is the case, the subclass "
                     "should deal with the new arguments explicitely.")
@@ -407,6 +408,11 @@ class TestNeuralNet:
     def test_save_load_history_file_path(
             self, net_cls, module_cls, net_fit, tmpdir, converter):
         # Test loading/saving with different kinds of path representations.
+
+        if converter is Path and sys.version < '3.6':
+            # `PosixPath` cannot be `open`ed in Python < 3.6
+            pytest.skip()
+
         net = net_cls(module_cls).initialize()
 
         history_before = net_fit.history


### PR DESCRIPTION
There was nothing preventing the user from using skorch with Python 3.5 but some tests were not passing. This is fixed now.