### PR TITLE
Refactor epoch scoring easier subclassing

### DIFF
--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -324,16 +324,34 @@ class EpochScoring(ScoringBase):
             self.y_trues_.append(y)
         self.y_preds_.append(y_pred)
 
-    # pylint: disable=unused-argument,arguments-differ
-    def on_epoch_end(
-            self,
-            net,
-            dataset_train,
-            dataset_valid,
-            **kwargs):
+    def get_test_data(self, dataset):
+        """Return data needed to perform scoring.
 
-        dataset = dataset_train if self.on_train else dataset_valid
+        This is a convenience method that handles different types of
+        input data, use of cache, etc. for you.
 
+        Parameters
+        ----------
+        dataset
+          Incoming data or dataset from train or validation.
+
+        Returns
+        -------
+        X_test
+          Input data used for making the prediction.
+
+        y_test
+          Target ground truth. If caching was enabled, return cached
+          y_test.
+
+        y_pred : list
+          The predicted targets. If caching was disabled, the list is
+          empty. If caching was enabled, the list contains the batches
+          of the predictions. It may thus be necessary to concatenate
+          the output before working with it:
+          ``y_pred = np.concatenate(y_pred)``
+
+        """
         if self.use_caching:
             X_test = dataset
             y_pred = self.y_preds_
@@ -341,36 +359,54 @@ class EpochScoring(ScoringBase):
             # In case of y=None we will not have gathered any samples.
             # We expect the scoring function to deal with y_test=None.
             y_test = np.concatenate(y_test) if y_test else None
-        else:
-            if is_skorch_dataset(dataset):
-                X_test, y_test = data_from_dataset(
-                    dataset,
-                    X_indexing=self.X_indexing_,
-                    y_indexing=self.y_indexing_,
-                )
-            else:
-                X_test, y_test = dataset, None
-            y_pred = []
-            if y_test is not None:
-                # We allow y_test to be None but the scoring function has
-                # to be able to deal with it (i.e. called without y_test).
-                y_test = self.target_extractor(y_test)
+            return X_test, y_test, y_pred
 
+        if is_skorch_dataset(dataset):
+            X_test, y_test = data_from_dataset(
+                dataset,
+                X_indexing=self.X_indexing_,
+                y_indexing=self.y_indexing_,
+            )
+        else:
+            X_test, y_test = dataset, None
+
+        if y_test is not None:
+            # We allow y_test to be None but the scoring function has
+            # to be able to deal with it (i.e. called without y_test).
+            y_test = self.target_extractor(y_test)
+        return X_test, y_test, []
+
+    def _record_score(self, history, current_score):
+        """Record the current store and, if applicable, if it's the best score
+        yet.
+
+        """
+        history.record(self.name_, current_score)
+
+        is_best = self._is_best_score(current_score)
+        if is_best is None:
+            return
+
+        history.record(self.name_ + '_best', bool(is_best))
+        if is_best:
+            self.best_score_ = current_score
+
+    # pylint: disable=unused-argument,arguments-differ
+    def on_epoch_end(
+            self,
+            net,
+            dataset_train,
+            dataset_valid,
+            **kwargs):
+        dataset = dataset_train if self.on_train else dataset_valid
+        X_test, y_test, y_pred = self.get_test_data(dataset)
         if X_test is None:
             return
 
         with cache_net_infer(net, self.use_caching, y_pred) as cached_net:
             current_score = self._scoring(cached_net, X_test, y_test)
 
-            cached_net.history.record(self.name_, current_score)
-
-            is_best = self._is_best_score(current_score)
-            if is_best is None:
-                return
-
-            cached_net.history.record(self.name_ + '_best', bool(is_best))
-            if is_best:
-                self.best_score_ = current_score
+        self._record_score(net.history, current_score)
 
     def on_train_end(self, *args, **kwargs):
         self._initialize_cache()

--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -324,16 +324,20 @@ class EpochScoring(ScoringBase):
             self.y_trues_.append(y)
         self.y_preds_.append(y_pred)
 
-    def get_test_data(self, dataset):
+    def get_test_data(self, dataset_train, dataset_valid):
         """Return data needed to perform scoring.
 
-        This is a convenience method that handles different types of
-        input data, use of cache, etc. for you.
+        This is a convenience method that handles picking of
+        train/valid, different types of input data, use of cache,
+        etc. for you.
 
         Parameters
         ----------
-        dataset
-          Incoming data or dataset from train or validation.
+        dataset_train
+          Incoming training data or dataset.
+
+        dataset_valid
+          Incoming validation data or dataset.
 
         Returns
         -------
@@ -352,6 +356,8 @@ class EpochScoring(ScoringBase):
           ``y_pred = np.concatenate(y_pred)``
 
         """
+        dataset = dataset_train if self.on_train else dataset_valid
+
         if self.use_caching:
             X_test = dataset
             y_pred = self.y_preds_
@@ -398,8 +404,7 @@ class EpochScoring(ScoringBase):
             dataset_train,
             dataset_valid,
             **kwargs):
-        dataset = dataset_train if self.on_train else dataset_valid
-        X_test, y_test, y_pred = self.get_test_data(dataset)
+        X_test, y_test, y_pred = self.get_test_data(dataset_train, dataset_valid)
         if X_test is None:
             return
 

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -458,11 +458,10 @@ class TestEpochScoring:
             assert id(c1) == id(c2)
 
     def test_subclassing_epoch_scoring(
-            self, net_cls, classifier_module, classifier_data):
+            self, classifier_module, classifier_data):
         # This test's purpose is to check that it is possible to
         # easily subclass EpochScoring by overriding on_epoch_end to
         # record 2 scores.
-        from sklearn.metrics import accuracy_score
         from skorch import NeuralNetClassifier
         from skorch.callbacks import EpochScoring
 
@@ -473,7 +472,8 @@ class TestEpochScoring:
                     dataset_train,
                     dataset_valid,
                     **kwargs):
-                _, y_test, y_proba = self.get_test_data(dataset_valid)
+                _, y_test, y_proba = self.get_test_data(
+                    dataset_train, dataset_valid)
                 y_pred = np.concatenate(y_proba).argmax(1)
 
                 # record 2 valid scores

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -457,6 +457,46 @@ class TestEpochScoring:
         for c1, c2 in zip(cbs['a1'].y_trues_, cbs['a2'].y_trues_):
             assert id(c1) == id(c2)
 
+    def test_subclassing_epoch_scoring(
+            self, net_cls, classifier_module, classifier_data):
+        # This test's purpose is to check that it is possible to
+        # easily subclass EpochScoring by overriding on_epoch_end to
+        # record 2 scores.
+        from sklearn.metrics import accuracy_score
+        from skorch import NeuralNetClassifier
+        from skorch.callbacks import EpochScoring
+
+        class MyScoring(EpochScoring):
+            def on_epoch_end(
+                    self,
+                    net,
+                    dataset_train,
+                    dataset_valid,
+                    **kwargs):
+                _, y_test, y_proba = self.get_test_data(dataset_valid)
+                y_pred = np.concatenate(y_proba).argmax(1)
+
+                # record 2 valid scores
+                score_0_valid = accuracy_score(y_test, y_pred)
+                net.history.record('score_0', score_0_valid)
+                score_1_valid = accuracy_score(y_test, y_pred) + 1
+                net.history.record('score_1', score_1_valid)
+
+        X, y = classifier_data
+        net = NeuralNetClassifier(
+            classifier_module,
+            callbacks=[MyScoring(scoring=None)],
+            max_epochs=1,
+        )
+        net.fit(X, y)
+
+        row = net.history[-1]
+        keys_history = set(row.keys())
+        keys_expected = {'score_0', 'score_1'}
+
+        assert keys_expected.issubset(keys_history)
+        assert np.isclose(row['score_0'], row['score_1'] - 1)
+
 
 class TestBatchScoring:
     @pytest.fixture(params=[{'use_caching': True}, {'use_caching': False}])


### PR DESCRIPTION
With the old implementation, a lot of code needs to be duplicated if `on_epoch_end` is overridden, making it difficult for users to implement their own `EpochScoring`. This is greatly facilitated now (see unit test for an example).