### PR TITLE
deprecate filtered optimizer

### DIFF
--- a/notebooks/Transfer_Learning.ipynb
+++ b/notebooks/Transfer_Learning.ipynb
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,9 +62,7 @@
     "from torchvision import datasets, models, transforms\n",
     "\n",
     "from skorch import NeuralNetClassifier\n",
-    "from skorch.callbacks import LRScheduler, Checkpoint\n",
-    "from skorch.helper import filtered_optimizer\n",
-    "from skorch.helper import filter_requires_grad\n",
+    "from skorch.callbacks import LRScheduler, Checkpoint, Freezer\n",
     "from skorch.helper import predefined_split\n",
     "\n",
     "torch.manual_seed(360);"
@@ -86,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -107,7 +105,7 @@
     "        if not os.path.exists(data_zip):\n",
     "            print(\"Starting to download data...\")\n",
     "            data = request.urlopen(url, timeout=15).read()\n",
-    "            with open(data_path, 'wb') as f:\n",
+    "            with open(data_zip, 'wb') as f:\n",
     "                f.write(data)\n",
     "\n",
     "        print(\"Starting to extract data...\")\n",
@@ -135,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,17 +196,6 @@
    "metadata": {},
    "source": [
     "Since we are training a binary classifier, the output of the final fully connected layer has size 2. Next, we freeze all layers except the final layer by setting `requires_grad` to False:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for name, param in model_ft.named_parameters():\n",
-    "    if not name.startswith('fc'):\n",
-    "        param.requires_grad_(False)"
    ]
   },
   {
@@ -236,43 +223,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, we create two callbacks:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lrscheduler = LRScheduler(\n",
-    "    policy='StepLR', step_size=7, gamma=0.1)\n",
-    "\n",
-    "checkpoint = Checkpoint(\n",
-    "    f_params='best_model.pt', monitor='valid_acc_best')\n",
-    "\n",
-    "callbacks = [lrscheduler, checkpoint]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The `LRScheduler` callback defines a learning rate scheduler that uses `torch.optim.lr_scheduler.StepLR` to scale learning rates by `gamma=0.1` every 7 steps. The `Checkpoint` callback saves the best model by by monitoring the validation accuracy."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Filtered optimizer"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Since we froze some layers in our `Resnet18` neutral network, we need to configure our optimizer to only update gradients in our final fully connected layer. Luckily, `skorch` provides two functions that make this simple:"
+    "First, we create three callbacks:"
    ]
   },
   {
@@ -281,16 +232,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "optimizer = filtered_optimizer(\n",
-    "    optim.SGD, filter_requires_grad\n",
-    ")"
+    "freezer = Freezer(\n",
+    "    patterns=lambda name: not name.startswith('fc'))\n",
+    "\n",
+    "lrscheduler = LRScheduler(\n",
+    "    policy='StepLR', step_size=7, gamma=0.1)\n",
+    "\n",
+    "checkpoint = Checkpoint(\n",
+    "    f_params='best_model.pt', monitor='valid_acc_best')\n",
+    "\n",
+    "callbacks = [freezer, lrscheduler, checkpoint]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This function does not do any processing and returns the two datasets. "
+    "The `Freezer` callback freezes all layers except the `fc` output layers. \n",
+    "The `LRScheduler` callback defines a learning rate scheduler that uses `torch.optim.lr_scheduler.StepLR` to scale learning rates by `gamma=0.1` every 7 steps. The `Checkpoint` callback saves the best model by by monitoring the validation accuracy."
    ]
   },
   {
@@ -319,7 +278,7 @@
     "    lr=0.001,\n",
     "    batch_size=4,\n",
     "    max_epochs=25,\n",
-    "    optimizer=optimizer,\n",
+    "    optimizer=optim.SGD,\n",
     "    optimizer__momentum=0.9,\n",
     "    iterator_train__shuffle=True,\n",
     "    iterator_train__num_workers=4,\n",
@@ -342,7 +301,7 @@
     "3. `lr`: Initial learning rate\n",
     "4. `batch_size`: Size of a batch\n",
     "5. `max_epochs`: Number of epochs to train\n",
-    "6. `optimizer`: Our filtered optimizer\n",
+    "6. `optimizer`: Our optimizer\n",
     "7. `optimizer__momentum`: The initial momentum\n",
     "8. `iterator_{train,valid}__{shuffle,num_workers}`: Parameters that are passed to the dataloader.\n",
     "9. `train_split`: A wrapper around `val_ds` to use our validation dataset.\n",
@@ -363,31 +322,31 @@
      "text": [
       "  epoch    train_loss    valid_acc    valid_loss    cp     dur\n",
       "-------  ------------  -----------  ------------  ----  ------\n",
-      "      1        \u001b[36m0.8333\u001b[0m       \u001b[32m0.9346\u001b[0m        \u001b[35m0.2150\u001b[0m     +  1.4656\n",
-      "      2        \u001b[36m0.5203\u001b[0m       0.9150        0.2439        1.2813\n",
-      "      3        \u001b[36m0.4469\u001b[0m       0.8693        0.3494        1.2942\n",
-      "      4        0.4665       \u001b[32m0.9542\u001b[0m        \u001b[35m0.1949\u001b[0m     +  1.2363\n",
-      "      5        \u001b[36m0.3884\u001b[0m       0.9412        0.1962        1.2834\n",
-      "      6        \u001b[36m0.3807\u001b[0m       0.9412        \u001b[35m0.1923\u001b[0m        1.3064\n",
-      "      7        \u001b[36m0.3292\u001b[0m       0.9412        \u001b[35m0.1876\u001b[0m        1.3428\n",
-      "      8        \u001b[36m0.2864\u001b[0m       0.9412        0.1961        1.3132\n",
-      "      9        0.4199       0.9346        0.1987        1.2935\n",
-      "     10        0.4462       0.9412        0.2054        1.2886\n",
-      "     11        0.2971       0.9412        0.1952        1.4172\n",
-      "     12        0.3474       0.9412        0.2092        1.3306\n",
-      "     13        0.2891       0.9412        0.2285        1.2747\n",
-      "     14        0.3648       0.8889        0.2870        1.3012\n",
-      "     15        0.3090       0.9346        0.2029        1.2845\n",
-      "     16        0.3348       0.9281        0.2345        1.3291\n",
-      "     17        0.2940       0.9412        0.1908        1.2621\n",
-      "     18        0.3961       0.9412        0.2181        1.3413\n",
-      "     19        0.3652       0.9281        0.2256        1.2868\n",
-      "     20        0.3038       0.9346        0.2178        1.3177\n",
-      "     21        0.3489       0.9477        0.2041        1.2754\n",
-      "     22        0.3161       0.9477        \u001b[35m0.1848\u001b[0m        1.2837\n",
-      "     23        \u001b[36m0.2622\u001b[0m       0.9477        0.2074        1.3112\n",
-      "     24        0.3823       0.9477        0.1923        1.2328\n",
-      "     25        0.2952       0.9412        0.2223        1.3896\n"
+      "      1        \u001b[36m0.8220\u001b[0m       \u001b[32m0.9150\u001b[0m        \u001b[35m0.2294\u001b[0m     +  3.2474\n",
+      "      2        \u001b[36m0.4949\u001b[0m       \u001b[32m0.9346\u001b[0m        \u001b[35m0.2116\u001b[0m     +  3.1053\n",
+      "      3        \u001b[36m0.4873\u001b[0m       0.8105        0.4593        3.1002\n",
+      "      4        0.5291       \u001b[32m0.9477\u001b[0m        \u001b[35m0.1725\u001b[0m     +  3.2296\n",
+      "      5        \u001b[36m0.4530\u001b[0m       0.9216        0.2275        3.1079\n",
+      "      6        \u001b[36m0.3869\u001b[0m       0.9412        \u001b[35m0.1697\u001b[0m        3.1566\n",
+      "      7        \u001b[36m0.2903\u001b[0m       \u001b[32m0.9608\u001b[0m        0.1778     +  3.1729\n",
+      "      8        0.3000       0.9477        0.1769        3.0686\n",
+      "      9        0.4068       0.9542        0.1830        3.1405\n",
+      "     10        0.5076       0.9281        0.1953        3.1769\n",
+      "     11        0.3271       0.9346        0.1911        3.1532\n",
+      "     12        0.3728       0.9281        0.2180        3.1394\n",
+      "     13        \u001b[36m0.2847\u001b[0m       0.9477        0.1847        3.1390\n",
+      "     14        0.3526       0.9216        0.2333        3.1666\n",
+      "     15        0.3254       0.9281        0.1802        3.1555\n",
+      "     16        0.3407       0.9477        0.1888        3.1696\n",
+      "     17        \u001b[36m0.2498\u001b[0m       0.9346        0.1931        3.1973\n",
+      "     18        0.4421       0.9477        0.1848        3.3780\n",
+      "     19        0.3548       0.9216        0.2010        3.2392\n",
+      "     20        0.3037       0.9281        0.2188        3.2800\n",
+      "     21        0.3454       0.9542        0.1837        3.1598\n",
+      "     22        0.3227       0.9412        0.1732        3.2227\n",
+      "     23        0.2595       0.9542        0.1765        3.1960\n",
+      "     24        0.3164       0.9477        0.1794        3.1500\n",
+      "     25        0.2607       0.9412        0.1934        3.2597\n"
      ]
     }
    ],
@@ -399,7 +358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The best model is stored at `best_model.pt`, with a validiation accuracy of roughly 0.95.\n",
+    "The best model is stored at `best_model.pt`, with a validiation accuracy of roughly 0.96.\n",
     "\n",
     "Congrualations! You now know how to finetune a neutral network using `skorch`. Feel free to explore the other tutorials to learn more about using `skorch`."
    ]
@@ -407,7 +366,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -421,7 +380,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/skorch/helper.py
+++ b/skorch/helper.py
@@ -4,6 +4,8 @@ They should not be used in skorch directly.
 
 """
 from functools import partial
+import warnings
+
 from skorch.utils import _make_split
 from skorch.utils import _make_optimizer
 
@@ -83,6 +85,7 @@ class SliceDict(dict):
         return (self._len,)
 
 
+# TODO: remove in 0.5.0
 def filter_requires_grad(pgroups):
     """Returns parameter groups where parameters
     that don't require a gradient are filtered out.
@@ -93,12 +96,17 @@ def filter_requires_grad(pgroups):
       Parameter groups to be filtered
 
     """
+    warnings.warn(
+        "For filtering gradients, please use skorch.callbacks.Freezer.",
+        DeprecationWarning)
+
     for pgroup in pgroups:
         output = {k: v for k, v in pgroup.items() if k != 'params'}
         output['params'] = (p for p in pgroup['params'] if p.requires_grad)
         yield output
 
 
+# TODO: remove in 0.5.0
 def filtered_optimizer(optimizer, filter_fn):
     """Wraps an optimizer that filters out parameters where
     ``filter_fn`` over ``pgroups`` returns ``False``.
@@ -119,6 +127,10 @@ def filtered_optimizer(optimizer, filter_fn):
       it to ``optimizer``.
 
     """
+    warnings.warn(
+        "For filtering gradients, please use skorch.callbacks.Freezer.",
+        DeprecationWarning)
+
     return partial(_make_optimizer, optimizer=optimizer, filter_fn=filter_fn)
 
 


### PR DESCRIPTION
Work in progress and open for discussion.

Updates notebooks that freeze parameters and deprecates `filtered_optimizer` et al.