### PR TITLE
[MRG] Adds optimizer and history to save/load_params

### DIFF
--- a/docs/user/callbacks.rst
+++ b/docs/user/callbacks.rst
@@ -225,8 +225,10 @@ starting with ``f_``:
 
 - ``f_params``: to save model parameters (uses
   :func:`~skorch.net.NeuralNet.save_params`);
+- ``f_optimizer``: to save optimizer state (uses
+  :func:`~skorch.net.NeuralNet.save_params`);
 - ``f_history``: to save training history (uses
-  :func:`~skorch.net.NeuralNet.save_history`);
+  :func:`~skorch.net.NeuralNet.save_params`);
 - ``f_pickle``: to pickle the entire model object.
 
 Please refer to :ref:`saving and loading` for more information about

--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -419,10 +419,10 @@ initialize a :class:`.NeuralNet` to load the parameters again:
     new_net.initialize()  # This is important!
     new_net.load_params('some-file.pkl')
 
-In addition to saving the model parameters, the history
-can be saved and loaded by calling the
-:func:`~skorch.net.NeuralNet.save_history`
-and :func:`~skorch.net.NeuralNet.load_history` methods on
+In addition to saving the model parameters, the history and optimizer state can
+be saved by including the `f_history` and `f_optimizer` keywords to
+:func:`~skorch.net.NeuralNet.save_params` and
+:func:`~skorch.net.NeuralNet.load_params` on
 :class:`.NeuralNet`. This feature can be used to
 continue training:
 
@@ -435,16 +435,16 @@ continue training:
 
     net.fit(X, y, epochs=2) # Train for 2 epochs
 
-    net.save_params('some-file.pkl')
-    net.save_history('history.json')
+    net.save_params(
+        'model.pkl', f_optimizer='opt.pkl', f_history='history.json')
 
     new_net = NeuralNet(
         module=MyModule
         criterion=torch.nn.NLLLoss,
     )
     new_net.initialize() # This is important!
-    new_net.load_params('some-file.pkl')
-    new_net.load_history('history.json')
+    new_net.load_params(
+        'model.pkl', f_optimizer='opt.pkl', f_history='history.json')
 
     new_net.fit(X, y, epochs=2) # Train for another 2 epochs
 

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -107,10 +107,10 @@ class TestEpochScoring:
         net.fit(*data)
 
         history_fn = tmpdir.mkdir('skorch').join('history.json')
-        net.save_history(str(history_fn))
+        net.save_params(f_history=str(history_fn))
 
         net.initialize()
-        net.load_history(str(history_fn))
+        net.load_params(f_history=str(history_fn))
         net.max_epochs = 5 - initial_epochs
         net.partial_fit(*data)
 
@@ -622,11 +622,11 @@ class TestBatchScoring:
         net.fit(*data)
 
         history_fn = tmpdir.mkdir('skorch').join('history.json')
-        net.save_history(str(history_fn))
+        net.save_params(f_history=str(history_fn))
 
         net.max_epochs = 5 - initial_epochs
         net.initialize()
-        net.load_history(str(history_fn))
+        net.load_params(f_history=str(history_fn))
         net.partial_fit(*data)
 
         is_best = net.history[:, 'score_best']

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -17,12 +17,6 @@ class TestCheckpoint:
     @pytest.fixture
     def save_params_mock(self):
         with patch('skorch.NeuralNet.save_params') as mock:
-            mock.side_effect = lambda x: x
-            yield mock
-
-    @pytest.fixture
-    def save_history_mock(self):
-        with patch('skorch.NeuralNet.save_history') as mock:
             yield mock
 
     @pytest.fixture
@@ -101,34 +95,36 @@ class TestCheckpoint:
             checkpoint_cls(
                 monitor='epoch_3_scorer',
                 f_params='model_{last_epoch[epoch]}_{net.max_epochs}.pt',
+                f_optimizer='optimizer_{last_epoch[epoch]}_{net.max_epochs}.pt',
                 sink=sink),
         ])
         net.fit(*data)
 
         assert save_params_mock.call_count == 1
-        save_params_mock.assert_called_with('model_3_10.pt')
+        save_params_mock.assert_called_with(
+            'model_3_10.pt', f_optimizer='optimizer_3_10.pt', f_history=None)
         assert sink.call_count == 1
         assert all((x is False) for x in net.history[:2, 'event_cp'])
         assert net.history[2, 'event_cp'] is True
         assert all((x is False) for x in net.history[3:, 'event_cp'])
 
     def test_save_all_targets(
-            self, save_params_mock, save_history_mock, pickle_dump_mock,
+            self, save_params_mock, pickle_dump_mock,
             net_cls, checkpoint_cls, data):
         net = net_cls(callbacks=[
             checkpoint_cls(monitor=None, f_params='params.pt',
-                f_history='history.json', f_pickle='model.pkl'),
+                f_history='history.json', f_pickle='model.pkl',
+                f_optimizer='optimizer.pt'),
         ])
         net.fit(*data)
 
         assert save_params_mock.call_count == len(net.history)
-        assert save_history_mock.call_count == len(net.history)
         assert pickle_dump_mock.call_count == len(net.history)
-        save_params_mock.assert_called_with('params.pt')
-        save_history_mock.assert_called_with('history.json')
+        save_params_mock.assert_called_with(
+            'params.pt', f_optimizer='optimizer.pt', f_history='history.json')
 
     def test_save_no_targets(
-            self, save_params_mock, save_history_mock, pickle_dump_mock,
+            self, save_params_mock, pickle_dump_mock,
             net_cls, checkpoint_cls, data):
         net = net_cls(callbacks=[
             checkpoint_cls(monitor=None, f_params=None, f_history=None,
@@ -137,7 +133,6 @@ class TestCheckpoint:
         net.fit(*data)
 
         assert save_params_mock.call_count == 0
-        assert save_history_mock.call_count == 0
         assert pickle_dump_mock.call_count == 0
 
     def test_target_argument(self, net_cls, checkpoint_cls):


### PR DESCRIPTION
Fixes #357

1. Adds optimizer and history to `save_params` and `load_params`. Deprecates using `f`.
2. Adds the optimizer option to `Checkpoint`.
3. Deprecates `save_history` and `load_history` in favor of `save_params` and `load_params` to save history. This simplifies the skorch api to only needing `save_params` and `load_params` to save/load state.

This PR can merge easily with #358 by replacing `_get_state_dict` with the implementation in #358 and returning the state dict.