### PR TITLE
BUG: Fixes ReduceLROnPlateau when mode == max

### DIFF
--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -112,7 +112,13 @@ class LRScheduler(Callback):
             if callable(self.monitor):
                 score = self.monitor(net)
             else:
-                score = net.history[-2, self.monitor] if epoch else np.inf
+                if epoch:
+                    score = net.history[-2, self.monitor]
+                else:
+                    if self.lr_scheduler_.mode == 'max':
+                        score = -np.inf
+                    else:
+                        score = np.inf
             self.lr_scheduler_.step(score, epoch)
         else:
             self.lr_scheduler_.step(epoch)

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -183,6 +183,26 @@ class TestReduceLROnPlateau:
         score = mock_step.call_args_list[0][0][0]
         assert score == 55
 
+    @pytest.mark.parametrize('mode,score', [
+        ('min', np.inf),
+        ('max', -np.inf)
+    ])
+    def test_reduce_lr_monitor_max(
+            self, classifier_data, classifier_module, mode, score):
+        X, y = classifier_data
+        net = NeuralNetClassifier(
+            classifier_module,
+            callbacks=[
+                ('scheduler', LRScheduler(
+                    ReduceLROnPlateau, monitor='train_loss', mode=mode)),
+            ],
+            max_epochs=1,
+        )
+        net.fit(X, y)
+
+        policy = dict(net.callbacks_)['scheduler'].lr_scheduler_
+        assert policy.best == score
+
 
 class TestWarmRestartLR():
     def assert_lr_correct(


### PR DESCRIPTION
Fixes #363

This PR works because `ReduceLROnPlateru` only has two modes: `max` and `min`.