### PR TITLE
Unify device handling in __setstate__ and load_params

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -24,6 +24,7 @@ from skorch.exceptions import NotInitializedError
 from skorch.history import History
 from skorch.utils import FirstStepAccumulator
 from skorch.utils import duplicate_items
+from skorch.utils import get_map_location
 from skorch.utils import is_dataset
 from skorch.utils import noop
 from skorch.utils import params_for
@@ -1319,11 +1320,11 @@ class NeuralNet(object):
         return state
 
     def __setstate__(self, state):
-        # _get_map_location will automatically choose the
+        # get_map_location will automatically choose the
         # right device in cases where CUDA is not available.
-        map_location = self._get_map_location(state['device'])
+        map_location = get_map_location(state['device'])
         load_kwargs = {'map_location': map_location}
-        self._handle_mismatched_devices(state, map_location)
+        state['device'] = self._check_device(state['device'], map_location)
 
         with tempfile.SpooledTemporaryFile() as f:
             f.write(state['cuda_dependent_attributes_'])
@@ -1409,33 +1410,20 @@ class NeuralNet(object):
         if f_history is not None:
             self.history.to_file(f_history)
 
-    def _get_map_location(self, target_device):
-        """Determine the location to map loaded data (e.g., weights)
-        for a given target device (e.g. 'cuda').
+    def _check_device(self, requested_device, map_device):
+        """Compare the requested device with the map device and
+        return the map device if it differs from the requested device
+        along with a warning.
         """
-        map_location = torch.device(target_device)
-
-        # The user wants to use CUDA but there is no CUDA device
-        # available, thus fall back to CPU.
-        if target_device.startswith('cuda') and not torch.cuda.is_available():
-            warnings.warn(
-                'Requested to load data to CUDA but no CUDA devices '
-                'are available. Loading on CPU instead.',
-                DeviceWarning)
-            map_location = torch.device('cpu')
-        return map_location
-
-    def _handle_mismatched_devices(self, net_state, map_device):
-        """Warn the user and update the network state to use a non-cuda device
-        in case the network state requests e.g. CUDA but CUDA is not available.
-        """
-        requested_device = net_state['device']
-        if torch.device(requested_device) != torch.device(map_device):
-            net_state['device'] = map_device
+        type_1 = torch.device(requested_device)
+        type_2 = torch.device(map_device)
+        if type_1 != type_2:
             warnings.warn(
                 'Setting self.device = {} since the requested device ({}) '
                 'is not available.'.format(map_device, requested_device),
                 DeviceWarning)
+            return map_device
+        return requested_device
 
     def load_params(
             self, f=None, f_params=None, f_optimizer=None, f_history=None,
@@ -1479,8 +1467,8 @@ class NeuralNet(object):
 
         """
         def _get_state_dict(f):
-            map_location = self._get_map_location(self.device)
-            self._handle_mismatched_devices(self.__dict__, map_location)
+            map_location = get_map_location(self.device)
+            self.device = self._check_device(self.device, map_location)
             return torch.load(f, map_location=map_location)
 
         # TODO: Remove warning in a future release

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1423,6 +1423,8 @@ class NeuralNet(object):
                 'is not available.'.format(map_device, requested_device),
                 DeviceWarning)
             return map_device
+        # return requested_device instead of map_device even though we
+        # checked for *type* equality as we might have 'cuda:0' vs. 'cuda:1'.
         return requested_device
 
     def load_params(

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -304,7 +304,7 @@ class TestNeuralNet:
             assert len(w.list) == 2
             assert w.list[0].message.args[0] == (
                 'Requested to load data to CUDA but no CUDA devices '
-                'are available. Loading on CPU instead.')
+                'are available. Loading on device "cpu" instead.')
             assert w.list[1].message.args[0] == (
                 'Setting self.device = {} since the requested device ({}) '
                 'is not available.'.format(load_dev, save_dev))
@@ -623,7 +623,7 @@ class TestNeuralNet:
 
         assert w.list[0].message.args[0] == (
             'Requested to load data to CUDA but no CUDA devices '
-            'are available. Loading on CPU instead.')
+            'are available. Loading on device "cpu" instead.')
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda device")
     def test_save_params_cuda_load_params_cpu_when_cuda_available(

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -461,7 +461,8 @@ def get_map_location(target_device, fallback_device='cpu'):
     if map_location.type == 'cuda' and not torch.cuda.is_available():
         warnings.warn(
             'Requested to load data to CUDA but no CUDA devices '
-            'are available. Loading on CPU instead.',
-            DeviceWarning)
+            'are available. Loading on device "{}" instead.'.format(
+                fallback_device,
+            ), DeviceWarning)
         map_location = torch.device(fallback_device)
     return map_location


### PR DESCRIPTION
Before each of these functions had their own logic of
determining a fallback device if special devices such
as CUDA are not available. Now there is one common
way of handling this case.