### PR TITLE
Bugfix: Reinitialize optimizer when set_params is called with lr.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [1810251445]: https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Basic_Usage.ipynb
 
+### Fixed
+
+- Re-initialize optimizer when `set_params` is called with `lr` argument (#372)
+
 ## [0.4.0] - 2018-10-24
 
 ### Added

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1240,7 +1240,11 @@ class NeuralNet(object):
         if any(key.startswith('module') for key in special_params):
             self.initialize_module()
             self.initialize_optimizer()
-        if any(key.startswith('optimizer') for key in special_params):
+        optimizer_changed = (
+            any(key.startswith('optimizer') for key in special_params) or
+            'lr' in normal_params
+        )
+        if optimizer_changed:
             # Model selectors such as GridSearchCV will set the
             # parameters before .initialize() is called, therefore we
             # need to make sure that we have an initialized model here

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -843,6 +843,19 @@ class TestNeuralNet:
         # should not break
         net.set_params(optimizer=torch.optim.SGD)
 
+    def test_setting_lr_after_init_reflected_in_optimizer(
+            self, net_cls, module_cls):
+        # Fixes a bug that occurred when using set_params(lr=new_lr)
+        # after initialization: The new lr was not reflected in the
+        # optimizer.
+        net = net_cls(module_cls).initialize()
+        net.set_params(lr=10)
+        assert net.lr == 10
+
+        pg_lrs = [pg['lr'] for pg in net.optimizer_.param_groups]
+        for pg_lr in pg_lrs:
+            assert pg_lr == 10
+
     def test_optimizer_param_groups(self, net_cls, module_cls):
         net = net_cls(
             module_cls,


### PR DESCRIPTION
Previously, when the net was already initialized, calling
set_params(lr=new_lr) didn't trigger a re-initialization because the
method only looked for optimizer__* parameters. However, lr is
indirectly also an optimizer parameter, so setting it must
reinitialize the optimizer.