### PR TITLE
ENH: Early exit for train_loss_score and valid_loss_score already in history

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Advanced usage notebook][1810261633] now runs on Google Colab
 - [MNIST with scikit-learn and skorch][1811011230] now runs on Google Colab
 - Better user-facing messages when module or optimizer are re-initialized
+- Early exits `BatchScoring` when using `train_loss_score` or
+  `valid_loss_score`
 
 
 [1810251445]: https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Basic_Usage.ipynb

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Advanced usage notebook][1810261633] now runs on Google Colab
 - [MNIST with scikit-learn and skorch][1811011230] now runs on Google Colab
 - Better user-facing messages when module or optimizer are re-initialized
-- Early exits `BatchScoring` when using `train_loss_score` or
-  `valid_loss_score`
+- Reduce overhead of `BatchScoring` when using `train_loss_score` or `valid_loss_score` by skipping superfluous inference step (#381)
 
 
 [1810251445]: https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Basic_Usage.ipynb

--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -14,6 +14,8 @@ from skorch.utils import is_skorch_dataset
 from skorch.utils import to_numpy
 from skorch.callbacks import Callback
 from skorch.utils import check_indexing
+from skorch.utils import train_loss_score
+from skorch.utils import valid_loss_score
 
 
 __all__ = ['BatchScoring', 'EpochScoring']
@@ -183,6 +185,9 @@ class BatchScoring(ScoringBase):
 
     def on_batch_end(self, net, X, y, training, **kwargs):
         if training != self.on_train:
+            return
+
+        if self.scoring in [train_loss_score, valid_loss_score]:
             return
 
         y_preds = [kwargs['y_pred']]


### PR DESCRIPTION
When `train_loss_score` or `valid_loss_score` is set to be the `scoring` function, it already assumes that `train_loss` or `valid_loss` is already in the batch history. If the metric is not in the history, this will raise an `KeyError` which is ignored.

This PR checks for these scoring functions and returns early.