### PR TITLE
BUG: Disables cache in MNIST notebook

### DIFF
--- a/notebooks/MNIST.ipynb
+++ b/notebooks/MNIST.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mnist = fetch_openml('mnist_784', data_home='datasets')"
+    "mnist = fetch_openml('mnist_784', cache=False)"
    ]
   },
   {


### PR DESCRIPTION
Addresses https://github.com/dnouri/skorch/issues/382

In sklearn `0.20.0`, there is a bug with caching `fetch_openml`. This issue is fixed in sklearn `master`. For the time being disabling cache will allow this notebook to run.