### PR TITLE
RFC: Changes default fn_prefix in TrainEndCheckpoint to train_end_

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reduce overhead of `BatchScoring` when using `train_loss_score` or `valid_loss_score` by skipping superfluous inference step (#381)
 - The `on_grad_computed` callback function will yield an iterable for `named_parameters` only when it is used to reduce the run-time overhead of the call (#379)
+- Default `fn_prefix` in `TrainEndCheckpoint` is now `train_end_` (#391)
 
 ### Fixed
 

--- a/docs/user/save_load.rst
+++ b/docs/user/save_load.rst
@@ -144,7 +144,7 @@ and history into a directory named ``'exp1'``.
     from skorch.callbacks import Checkpoint, TrainEndCheckpoint
 
     cp = Checkpoint(dirname='exp1')
-    train_end_cp = TrainEndCheckpoint(dirname='exp1')
+    train_end_cp = TrainEndCheckpoint(dirname='exp1', fn_prefix='train_end_')
     net = NeuralNetClassifier(
         MyModule, lr=0.5, callbacks=[cp, train_end_cp]
     )

--- a/docs/user/save_load.rst
+++ b/docs/user/save_load.rst
@@ -144,9 +144,9 @@ and history into a directory named ``'exp1'``.
     from skorch.callbacks import Checkpoint, TrainEndCheckpoint
 
     cp = Checkpoint(dirname='exp1')
-    final_cp = TrainEndCheckpoint(dirname='exp1')
+    train_end_cp = TrainEndCheckpoint(dirname='exp1')
     net = NeuralNetClassifier(
-        MyModule, lr=0.5, callbacks=[cp, final_cp]
+        MyModule, lr=0.5, callbacks=[cp, train_end_cp]
     )
 
     _ = net.fit(X, y)
@@ -210,8 +210,8 @@ checkpoint can be passed to :class:`.LoadInitState` to continue training:
 
 .. code:: python
 
-    cp_from_final = Checkpoint(dirname='exp1', fn_prefix='from_final_')
-    load_state = LoadInitState(final_cp)
+    cp_from_final = Checkpoint(dirname='exp1', fn_prefix='from_train_end_')
+    load_state = LoadInitState(train_end_cp)
     net = NeuralNetClassifier(
         MyModule, lr=0.1, callbacks=[cp_from_final, load_state]
     )

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -600,16 +600,16 @@ class LoadInitState(Callback):
 
 class TrainEndCheckpoint(Checkpoint):
     """Saves the model parameters, optimizer state, and history at the end of
-    training. The default ``fn_prefix`` is 'final_'.
+    training. The default ``fn_prefix`` is 'train_end_'.
 
     Examples
     --------
 
     Consider running the following example multiple times:
 
-    >>> final_cp = TrainEndCheckpoint(dirname='exp1')
-    >>> load_state = LoadInitState(final_cp)
-    >>> net = NeuralNet(..., callbacks=[final_cp, load_state])
+    >>> train_end_cp = TrainEndCheckpoint(dirname='exp1')
+    >>> load_state = LoadInitState(train_end_cp)
+    >>> net = NeuralNet(..., callbacks=[train_end_cp, load_state])
     >>> net.fit(X, y)
 
     After the first run, model parameters, optimizer state, and history are
@@ -650,7 +650,7 @@ class TrainEndCheckpoint(Checkpoint):
 
       Supports the same format specifiers as ``f_params``.
 
-    fn_prefix: str (default='final_')
+    fn_prefix: str (default='train_end_')
       Prefix for filenames. If ``f_params``, ``f_optimizer``, ``f_history``,
       or ``f_pickle`` are strings, they will be prefixed by ``fn_prefix``.
 
@@ -668,7 +668,7 @@ class TrainEndCheckpoint(Checkpoint):
             f_optimizer='optimizer.pt',
             f_history='history.json',
             f_pickle=None,
-            fn_prefix='final_',
+            fn_prefix='train_end_',
             dirname='',
             sink=noop,
     ):

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -680,7 +680,7 @@ class TrainEndCheckpoint(Checkpoint):
         if fn_prefix is None:
             warnings.warn(
                 "'fn_prefix' default value will change from 'final_' "
-                "to 'train_end_' in 0.5.0")
+                "to 'train_end_' in 0.5.0", FutureWarning)
             fn_prefix = 'final_'
 
         super().__init__(

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -650,9 +650,12 @@ class TrainEndCheckpoint(Checkpoint):
 
       Supports the same format specifiers as ``f_params``.
 
-    fn_prefix: str (default='train_end_')
+    fn_prefix: str (default='final_')
       Prefix for filenames. If ``f_params``, ``f_optimizer``, ``f_history``,
       or ``f_pickle`` are strings, they will be prefixed by ``fn_prefix``.
+
+        ``fn_prefix`` default value will change from 'final_'
+        to 'train_end_' in 0.5.0.
 
     dirname: str (default='')
       Directory where files are stored.
@@ -668,10 +671,18 @@ class TrainEndCheckpoint(Checkpoint):
             f_optimizer='optimizer.pt',
             f_history='history.json',
             f_pickle=None,
-            fn_prefix='train_end_',
+            fn_prefix=None,
             dirname='',
             sink=noop,
     ):
+
+        # TODO: Remove warning in release 0.5.0
+        if fn_prefix is None:
+            warnings.warn(
+                "'fn_prefix' default value will change from 'final_' "
+                "to 'train_end_' in 0.5.0")
+            fn_prefix = 'final_'
+
         super().__init__(
             monitor=None,
             f_params=f_params,

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -839,7 +839,8 @@ class TestTrainEndCheckpoint:
             self, save_params_mock, net_cls, finalcheckpoint_cls, data):
         sink = Mock()
         net = net_cls(callbacks=[
-            finalcheckpoint_cls(sink=sink, dirname='exp1')
+            finalcheckpoint_cls(
+                sink=sink, dirname='exp1', fn_prefix='train_end_')
         ])
         net.fit(*data)
 
@@ -858,7 +859,8 @@ class TestTrainEndCheckpoint:
             finalcheckpoint_cls(
                 sink=sink, dirname='exp1',
                 f_params='model_{last_epoch[epoch]}.pt',
-                f_optimizer='optimizer_{last_epoch[epoch]}.pt'
+                f_optimizer='optimizer_{last_epoch[epoch]}.pt',
+                fn_prefix='train_end_'
             )
         ])
         net.fit(*data)

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -846,9 +846,9 @@ class TestTrainEndCheckpoint:
         assert save_params_mock.call_count == 3
         assert sink.call_args == call("Final checkpoint triggered")
         save_params_mock.assert_has_calls([
-            call(f_params='exp1/final_params.pt'),
-            call(f_optimizer='exp1/final_optimizer.pt'),
-            call(f_history='exp1/final_history.json')
+            call(f_params='exp1/train_end_params.pt'),
+            call(f_optimizer='exp1/train_end_optimizer.pt'),
+            call(f_history='exp1/train_end_history.json')
         ])
 
     def test_saves_at_end_with_custom_formatting(
@@ -866,7 +866,7 @@ class TestTrainEndCheckpoint:
         assert save_params_mock.call_count == 3
         assert sink.call_args == call("Final checkpoint triggered")
         save_params_mock.assert_has_calls([
-            call(f_params='exp1/final_model_10.pt'),
-            call(f_optimizer='exp1/final_optimizer_10.pt'),
-            call(f_history='exp1/final_history.json')
+            call(f_params='exp1/train_end_model_10.pt'),
+            call(f_optimizer='exp1/train_end_optimizer_10.pt'),
+            call(f_history='exp1/train_end_history.json')
         ])


### PR DESCRIPTION
The default prefix for `TrainEndCheckpoint` is `final_`. This PR adjusts it to `train_end_` along with all the references to it.