### PR TITLE
ENH: Adds epoch_completed to history

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduce overhead of `BatchScoring` when using `train_loss_score` or `valid_loss_score` by skipping superfluous inference step (#381)
 - The `on_grad_computed` callback function will yield an iterable for `named_parameters` only when it is used to reduce the run-time overhead of the call (#379)
 - Default `fn_prefix` in `TrainEndCheckpoint` is now `train_end_` (#391)
+- Adds `epoch_completed` to history to signal when an epoch has completed without interruption. (#387)
 
 ### Fixed
 

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -145,7 +145,7 @@ class PrintLog(Callback):
 
         for key in sorted(keys):
             if not (
-                    (key in ('epoch', 'dur')) or
+                    (key in ('epoch', 'dur', 'epoch_completed')) or
                     (key in self.keys_ignored_) or
                     key.endswith('_best') or
                     key.startswith('event_')

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -5,6 +5,7 @@ from itertools import chain
 from collections import OrderedDict
 import tempfile
 import warnings
+from contextlib import suppress
 
 import numpy as np
 from sklearn.base import BaseEstimator
@@ -296,13 +297,19 @@ class NeuralNet:
     # pylint: disable=unused-argument
     def on_epoch_begin(self, net,
                        dataset_train=None, dataset_valid=None, **kwargs):
-        self.history.new_epoch()
-        self.history.record('epoch', len(self.history))
+        epoch_completed = True
+        with suppress(KeyError):
+            epoch_completed = self.history[-1, 'epoch_completed']
+
+        if epoch_completed:
+            self.history.new_epoch()
+            self.history.record('epoch', len(self.history))
+            self.history.record('epoch_completed', False)
 
     # pylint: disable=unused-argument
     def on_epoch_end(self, net,
                      dataset_train=None, dataset_valid=None, **kwargs):
-        pass
+        self.history.record('epoch_completed', True)
 
     # pylint: disable=unused-argument
     def on_batch_begin(self, net,


### PR DESCRIPTION
Resolves #387 

When dealing with histories without the `epoch_completed` signal, this PR keeps the old behavior of just creating the new epoch in history. `test_on_epoch_begin_adds_new_epoch_when_completed_event_does_not_exist` tests for this behavior.

After this PR, the history will now include a `epoch_completed` flag that is set to False at the creation of the epoch. When the epoch finishes, then this flag is set to True.