### PR TITLE
[MRG] Warn user when using possibly wrong checkpoint monitor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduce overhead of `BatchScoring` when using `train_loss_score` or `valid_loss_score` by skipping superfluous inference step (#381)
 - The `on_grad_computed` callback function will yield an iterable for `named_parameters` only when it is used to reduce the run-time overhead of the call (#379)
 - Default `fn_prefix` in `TrainEndCheckpoint` is now `train_end_` (#391)
+- Issues a warning when `Checkpoints`'s `monitor` parameter is set to `monitor` and the history contains `<monitor>_best`. (#399)
 
 ### Fixed
 

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -163,8 +163,8 @@ class Checkpoint(Callback):
     def on_epoch_end(self, net, **kwargs):
         if "{}_best".format(self.monitor) in net.history[-1]:
             warnings.warn(
-                "Checkpoint monitor parameter is set to '{0}' and '{0}_best' "
-                "is in history. Perhaps you meant to set the parameter "
+                "Checkpoint monitor parameter is set to '{0}' and the history "
+                "contains '{0}_best'. Perhaps you meant to set the parameter "
                 "to '{0}_best'".format(self.monitor), UserWarning)
 
         if self.monitor is None:

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -161,6 +161,12 @@ class Checkpoint(Callback):
         return self
 
     def on_epoch_end(self, net, **kwargs):
+        if "{}_best".format(self.monitor) in net.history[-1]:
+            warnings.warn(
+                "Checkpoint monitor parameter is set to '{0}' and '{0}_best' "
+                "is in history. Perhaps you meant to set the parameter "
+                "to '{0}_best'".format(self.monitor), UserWarning)
+
         if self.monitor is None:
             do_checkpoint = True
         elif callable(self.monitor):

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -787,7 +787,7 @@ class TestLoadInitState:
             f_history=str(f_history)
         )
         load_init_state = loadinitstate_cls(cp)
-        net = net_cls(callbacks=[scoring, cp, load_init_state])
+        net = net_cls(callbacks=[load_init_state, scoring, cp])
 
         net.fit(*data)
 
@@ -798,7 +798,7 @@ class TestLoadInitState:
         assert len(net.history) == 10
         del net
 
-        new_net = net_cls(callbacks=[scoring, cp, load_init_state])
+        new_net = net_cls(callbacks=[load_init_state, scoring, cp])
         new_net.fit(*data)
 
         # new_net starts from the best epoch of the first run
@@ -807,7 +807,7 @@ class TestLoadInitState:
         # 3 + 10 = 13
         assert len(new_net.history) == 13
         assert new_net.history[:, 'event_cp'] == [
-            False, False, True] + [False] * 10
+            True, False, True] + [False] * 10
 
 
 class TestTrainEndCheckpoint:

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -186,6 +186,9 @@ class TestCheckpoint:
              call(f_history='history.json')]
         )
         assert sink.call_count == 2
+        # The first epoch will always be saved. `epoch_3_scorer` returns 1 at
+        # epoch 3, which will trigger another checkpoint. For all other epochs
+        # `epoch_3_scorer` returns 0, which does not trigger a checkpoint.
         assert [True, False, True] + [False] * 7 == net.history[:, 'event_cp']
 
     def test_save_all_targets(

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -290,8 +290,8 @@ class TestCheckpoint:
             max_epochs=1)
 
         exp_warn = (
-            "Checkpoint monitor parameter is set to 'valid_loss' and "
-            "'valid_loss_best' is in history. Perhaps you meant to set the "
+            "Checkpoint monitor parameter is set to 'valid_loss' and the "
+            "history contains 'valid_loss_best'. Perhaps you meant to set the "
             "parameter to 'valid_loss_best'")
 
         with pytest.warns(UserWarning, match=exp_warn):


### PR DESCRIPTION
Resolves #399

Updates some tests to use the `<monitor>_best` syntax for `Checkpoints`'s `monitor` parameter.