### PR TITLE
[MRG] Adds test for pytorch 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 python:
   - "3.7"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "3.6"
   - "3.5"
+env:
+  - PYTORCH_DEP=pytorch-cpu==0.4.1
 cache:
   apt: true
   timeout: 1000
@@ -26,6 +28,6 @@ install:
   - pip install tabulate
   - conda install --file=requirements-dev.txt
   - python setup.py install
-  - conda install -c pytorch 'pytorch>=1.0.0'
+  - conda install -c pytorch '${PYTORCH_DEP}'
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ install:
   - conda update -q conda
   - conda info -a
 
-  - conda create -y -n skorch-env python=${TRAVIS_PYTHON_VERSION} scikit-learn tqdm
+  - conda create -y -n skorch-env python=${TRAVIS_PYTHON_VERSION}
   - source activate skorch-env
-  - pip install tabulate
-  - conda install --file=requirements-dev.txt
+  - cat requirements.txt requirements-dev.txt > reqs.txt
+  - conda install --file=reqs.txt
   - python setup.py install
   - conda install -c pytorch pytorch-cpu==${PYTORCH_VERSION}
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.5"
 env:
   matrix:
-    - PYTORCH_VERSION="0.4.1"
     - PYTORCH_VERSION="1.0.0"
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
-language: python
-python:
-  - "3.6"
-  - "3.5"
 env:
-  - PYTORCH_DEP="pytorch-cpu==0.4.1"
+  matrix:
+    - PYTHON_VERSION="3.5" \
+      PYTORCH_WHL="http://download.pytorch.org/whl/cpu/torch-1.0.0-cp35-cp35m-linux_x86_64.whl"
+    - PYTHON_VERSION="3.6" \
+      PYTORCH_WHL="http://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-linux_x86_64.whl"
+    - PYTHON_VERSION="3.7" \
+      PYTORCH_WHL="http://download.pytorch.org/whl/cpu/torch-1.0.0-cp37-cp37m-linux_x86_64.whl"
 cache:
   apt: true
   timeout: 1000
@@ -23,11 +25,11 @@ install:
   - conda update -q conda
   - conda info -a
 
-  - conda create -y -n skorch-env python=${TRAVIS_PYTHON_VERSION} scikit-learn
+  - conda create -y -n skorch-env python=${PYTHON_VERSION} scikit-learn
   - source activate skorch-env
   - pip install tabulate
   - conda install --file=requirements-dev.txt
   - python setup.py install
-  - conda install -c pytorch $PYTORCH_DEP
+  - pip install ${PYTORCH_WHL}
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,9 @@ install:
 
   - conda create -y -n skorch-env python=${TRAVIS_PYTHON_VERSION}
   - source activate skorch-env
-  - pip install tabulate==0.7.7
   - cat requirements.txt requirements-dev.txt > reqs.txt
   - conda install --file=reqs.txt
-  - python setup.py install
+  - pip install -e .
   - conda install -c pytorch pytorch-cpu==${PYTORCH_VERSION}
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - source activate skorch-env
   - cat requirements.txt requirements-dev.txt > reqs.txt
   - conda install --file=reqs.txt
-  - pip install -e .
+  - pip install .
   - conda install -c pytorch pytorch-cpu==${PYTORCH_VERSION}
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.6"
   - "3.5"
 env:
-  - PYTORCH_DEP=pytorch-cpu==0.4.1
+  - PYTORCH_DEP="pytorch-cpu==0.4.1"
 cache:
   apt: true
   timeout: 1000
@@ -28,6 +28,6 @@ install:
   - pip install tabulate
   - conda install --file=requirements-dev.txt
   - python setup.py install
-  - conda install -c pytorch '${PYTORCH_DEP}'
+  - conda install -c pytorch $PYTORCH_DEP
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
 
   - conda create -y -n skorch-env python=${TRAVIS_PYTHON_VERSION}
   - source activate skorch-env
+  - pip install tabulate==0.7.7
   - cat requirements.txt requirements-dev.txt > reqs.txt
   - conda install --file=reqs.txt
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - source activate skorch-env
   - cat requirements.txt requirements-dev.txt > reqs.txt
   - conda install --file=reqs.txt
-  - pip install .
+	- python setup.py install
   - conda install -c pytorch pytorch-cpu==${PYTORCH_VERSION}
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 env:
+  global:
+    - PYTORCH_VERSION="1.0.0"
   matrix:
-    - PYTHON_VERSION="3.5" \
-      PYTORCH_WHL="http://download.pytorch.org/whl/cpu/torch-1.0.0-cp35-cp35m-linux_x86_64.whl"
-    - PYTHON_VERSION="3.6" \
-      PYTORCH_WHL="http://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-linux_x86_64.whl"
-    - PYTHON_VERSION="3.7" \
-      PYTORCH_WHL="http://download.pytorch.org/whl/cpu/torch-1.0.0-cp37-cp37m-linux_x86_64.whl"
+    - PYTHON_VERSION="3.5"
+    - PYTHON_VERSION="3.6"
+    - PYTHON_VERSION="3.7"
 cache:
   apt: true
   timeout: 1000
@@ -25,11 +24,12 @@ install:
   - conda update -q conda
   - conda info -a
 
-  - conda create -y -n skorch-env python=${PYTHON_VERSION} scikit-learn
+  - conda create -y -n skorch-env python=${PYTHON_VERSION} scikit-learn tqdm
   - source activate skorch-env
   - pip install tabulate
   - conda install --file=requirements-dev.txt
   - python setup.py install
+  - conda install -c pytorch pytorch-cpu==${PYTORCH_VERSION}
   - pip install ${PYTORCH_WHL}
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
+language: python
+python:
+  - "3.7"
+  - "3.6"
+  - "3.5"
 env:
-  global:
-    - PYTORCH_VERSION="1.0.0"
   matrix:
-    - PYTHON_VERSION="3.5"
-    - PYTHON_VERSION="3.6"
-    - PYTHON_VERSION="3.7"
+    - PYTORCH_VERSION="1.0.0"
+
 cache:
   apt: true
   timeout: 1000
@@ -24,7 +26,7 @@ install:
   - conda update -q conda
   - conda info -a
 
-  - conda create -y -n skorch-env python=${PYTHON_VERSION} scikit-learn tqdm
+  - conda create -y -n skorch-env python=${TRAVIS_PYTHON_VERSION} scikit-learn tqdm
   - source activate skorch-env
   - pip install tabulate
   - conda install --file=requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - source activate skorch-env
   - cat requirements.txt requirements-dev.txt > reqs.txt
   - conda install --file=reqs.txt
-  - python setup.py install
+  - pip install .
   - conda install -c pytorch pytorch-cpu==${PYTORCH_VERSION}
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - source activate skorch-env
   - cat requirements.txt requirements-dev.txt > reqs.txt
   - conda install --file=reqs.txt
-  - pip install .
+  - python setup.py install
   - conda install -c pytorch pytorch-cpu==${PYTORCH_VERSION}
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - source activate skorch-env
   - cat requirements.txt requirements-dev.txt > reqs.txt
   - conda install --file=reqs.txt
-	- python setup.py install
+  - pip install .
   - conda install -c pytorch pytorch-cpu==${PYTORCH_VERSION}
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.5"
 env:
   matrix:
+    - PYTORCH_VERSION="0.4.1"
     - PYTORCH_VERSION="1.0.0"
 
 cache:
@@ -33,6 +34,5 @@ install:
   - conda install --file=requirements-dev.txt
   - python setup.py install
   - conda install -c pytorch pytorch-cpu==${PYTORCH_VERSION}
-  - pip install ${PYTORCH_WHL}
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ install:
 
   - conda create -y -n skorch-env python=${TRAVIS_PYTHON_VERSION}
   - source activate skorch-env
-  - pip install tabulate==0.7.7
   - cat requirements.txt requirements-dev.txt > reqs.txt
   - conda install --file=reqs.txt
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,11 @@ install:
   - conda update -q conda
   - conda info -a
 
-  - conda env create -q -n skorch-env -f environment.yml python=${TRAVIS_PYTHON_VERSION}
+  - conda create -y -n skorch-env python=${TRAVIS_PYTHON_VERSION} scikit-learn
   - source activate skorch-env
+  - pip install tabulate
   - conda install --file=requirements-dev.txt
   - python setup.py install
-  - conda install -c pytorch 'pytorch-cpu>=0.4.1'
+  - conda install -c pytorch 'pytorch>=1.0.0'
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ python:
   - "3.6"
   - "3.5"
 env:
-  matrix:
-    - PYTORCH_VERSION="1.0.0"
+  - PYTORCH_VERSION="1.0.0"
 
 cache:
   apt: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML==3.12
 scikit-learn==0.19.1
 scipy==0.19.0
 tqdm==4.14.0
+tabulate==0.7.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ PyYAML==3.12
 scikit-learn==0.19.1
 scipy==0.19.0
 tqdm==4.14.0
-tabulate==0.7.7

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1355,9 +1355,9 @@ class TestNeuralNet:
         )
         result = net.__repr__()
         expected = """<class 'skorch.classifier.NeuralNetClassifier'>[uninitialized](
-  module=functools.partial(<class 'skorch.toy.MLPModule'>, output_nonlin=Softmax(), input_units=20, hidden_units=10, num_hidden=2, dropout=0.5),
+  module={},
   module__hidden_units=55,
-)"""
+)""".format(module_cls)
         assert result == expected
 
     def test_repr_initialized_works(self, net_cls, module_cls):


### PR DESCRIPTION
Originally, the tests only ran on python 3.6, since the `environment.yml` file fixes the python version to 3.6. This PR correctly tests for the different version of python.

`skorch/tests/test_net.py` had to be adjusted because of how `python 3.5` handles the ordering of parameters.

When newer versions of pytorch comes out we can add additional versions to the `env` item in the `.travis.yml` file.
