### PR TITLE
Add support for scipy sparse CSR matrices as input data.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Advanced usage notebook][1810261633] now runs on Google Colab
 - [MNIST with scikit-learn and skorch][1811011230] now runs on Google Colab
 - Better user-facing messages when module or optimizer are re-initialized
+- Support for scipy sparse CSR matrices as input (as, e.g., returned by sklearn's `CountVectorizer`); note that they are cast to dense matrices during batching
 
 [1810251445]: https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Basic_Usage.ipynb
 [1810261633]: https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Advanced_Usage.ipynb

--- a/docs/user/dataset.rst
+++ b/docs/user/dataset.rst
@@ -76,12 +76,19 @@ are not sufficient for our usecase; for instance, they don't work with
 
 - :class:`numpy.ndarray`\s
 - PyTorch :class:`~torch.Tensor`\s
+- scipy sparse CSR matrices
 - pandas DataFrames or Series
 
-In addition, you can pass dictionaries or lists of one of those data
-types, e.g. a dictionary of :class:`numpy.ndarray`\s. When you pass
-dictionaries, the keys of the dictionaries are used as the argument
-name for the :func:`~torch.nn.Module.forward` method of the net's
+Note that currently, sparse matrices are cast to dense arrays during
+batching, given that PyTorch support for sparse matrices is still very
+incomplete. If you would like to prevent that, you need to override
+the ``transform`` method of :class:`~torch.utils.data.Dataset`.
+
+In addition to the types above, you can pass dictionaries or lists of
+one of those data types, e.g. a dictionary of
+:class:`numpy.ndarray`\s. When you pass dictionaries, the keys of the
+dictionaries are used as the argument name for the
+:func:`~torch.nn.Module.forward` method of the net's
 ``module``. Similarly, the column names of pandas ``DataFrame``\s are
 used as argument names. The example below should illustrate how to use
 this feature:

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -138,6 +138,7 @@ class NeuralNetClassifier(NeuralNet):
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
@@ -171,6 +172,7 @@ class NeuralNetClassifier(NeuralNet):
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
@@ -300,6 +302,7 @@ class NeuralNetBinaryClassifier(NeuralNet):
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
@@ -333,6 +336,7 @@ class NeuralNetBinaryClassifier(NeuralNet):
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -664,6 +664,7 @@ class NeuralNet:
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
@@ -740,6 +741,7 @@ class NeuralNet:
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
@@ -785,6 +787,7 @@ class NeuralNet:
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
@@ -821,6 +824,7 @@ class NeuralNet:
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
@@ -871,6 +875,7 @@ class NeuralNet:
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
@@ -949,6 +954,7 @@ class NeuralNet:
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
@@ -985,6 +991,7 @@ class NeuralNet:
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
@@ -1017,6 +1024,7 @@ class NeuralNet:
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
@@ -1046,6 +1054,7 @@ class NeuralNet:
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset
@@ -1098,6 +1107,7 @@ class NeuralNet:
             * numpy arrays
             * torch tensors
             * pandas DataFrame or Series
+            * scipy sparse CSR matrices
             * a dictionary of the former three
             * a list/tuple of the former three
             * a Dataset

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -61,7 +61,9 @@ def to_tensor(X, device, accept_sparse=False):
       module.
 
     accept_sparse : bool (default=False)
-      Whether to accept sparse matrices as input.
+      Whether to accept scipy sparse matrices as input. If False,
+      passing a sparse matrix raises an error. If True, it is
+      converted to a torch COO tensor.
 
     Returns
     -------


### PR DESCRIPTION
Among other use cases, this allows to use transformers that return
sparse matrices in the model pipeline, e.g. sklearn's
`CountVectorizer`. Previously, data needed to be cast to dense arrays
before passing it to skorch.

Note that during batching, data is cast to dense because pytorch's
`DataLoader` cannot deal with sparse matrices. But even if it could, it
would be of little use because torch support for sparse arrays is very
incomplete at this time (e.g. nn.Linear does not work in
backwards). Still this allows to avoid having to cast a potentially
huge input sparse matrix to dense so the feature should be useful.

This PR also updates to_tensor to allow casting a scipy sparse matrix
to a torch sparse COO tensor when accept_sparse=True. Even though
skorch does not use this feature, it seemed to be useful for this
function in general, since with pytorch 1.0, sparse support became
better overall.